### PR TITLE
Readme markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ```
   # install dependencies
-  go get github.com/xoebus/gocart/gocart
+  go get github.com/xoebus/gocart
   gocart install
 
   # run tests


### PR DESCRIPTION
Formats readme into markdown syntax to allow deep permalinks useful in mailing list exchanges
