### PR TITLE
Corrects go get path for gocart in README

### DIFF
--- a/README
+++ b/README
@@ -36,7 +36,7 @@
 = development
 
   # install dependencies
-  go get github.com/xoebus/gocart/gocart
+  go get github.com/vito/gocart
   gocart install
 
   # run tests


### PR DESCRIPTION
- The current development installation instructions point to a repo at
  github.com/xoebus/gocart/gocart. This repo has moved to vito/gocart.
