### PR TITLE
Swap ip range start and end when given in desc order

### DIFF
--- a/dynaml/call.go
+++ b/dynaml/call.go
@@ -1,6 +1,7 @@
 package dynaml
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"strings"
@@ -170,6 +171,7 @@ func staticIPPool(ranges []string) ([]net.IP, bool) {
 			end = net.ParseIP(strings.Trim(segments[1], " "))
 		}
 
+		start, end = sortIpRangeBoundaries(start, end)
 		ipPool = append(ipPool, ipRange(start, end)...)
 	}
 
@@ -198,4 +200,15 @@ func inc(ip net.IP) {
 			break
 		}
 	}
+}
+
+func sortIpRangeBoundaries(a, b net.IP) (net.IP, net.IP) {
+	cmp := bytes.Compare(a, b)
+	if cmp > 0 {
+		return b, a
+	} else if cmp < 0 {
+		return a, b
+	}
+
+	return a, b
 }

--- a/dynaml/call_test.go
+++ b/dynaml/call_test.go
@@ -145,5 +145,40 @@ var _ = Describe("calls", func() {
 				)
 			})
 		})
+
+		Context("when there is IP range in descending order", func() {
+			It("includes IPs in the pool in ascending order", func() {
+				subnets := parseYAML(`
+- static:
+    - 10.10.16.10 - 10.10.16.1
+`)
+
+				expr := CallExpr{
+					Name: "static_ips",
+					Arguments: []Expression{
+						IntegerExpr{0},
+						IntegerExpr{1},
+						IntegerExpr{2},
+					},
+				}
+
+				binding := FakeBinding{
+					FoundReferences: map[string]yaml.Node{
+						"name":      node("cf1"),
+						"instances": node(3),
+					},
+					FoundFromRoot: map[string]yaml.Node{
+						"networks.cf1.subnets": subnets,
+					},
+				}
+
+				Expect(expr).To(
+					EvaluateAs(
+						[]yaml.Node{node("10.10.16.1"), node("10.10.16.2"), node("10.10.16.3")},
+						binding,
+					),
+				)
+			})
+		})
 	})
 })


### PR DESCRIPTION
Hi

This PR fixes #36. Code rather straightforward, but in a few words it swaps range's start & end if they're given in a wrong order.