### PR TITLE
Add file path of the stub in the errors

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -4,7 +4,7 @@
 set -e -x -u
 
 #uses the local version of cover, if it is already checked out
-go get code.google.com/p/go.tools/cmd/cover
+go get golang.org/x/tools/cmd/cover
 
 export GOPATH=$PWD/Godeps/_workspace:$GOPATH
 

--- a/spiff.go
+++ b/spiff.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/codegangsta/cli"
@@ -62,12 +63,12 @@ func main() {
 func merge(templateFilePath string, stubFilePaths []string) {
 	templateFile, err := ioutil.ReadFile(templateFilePath)
 	if err != nil {
-		log.Fatalln("error reading template:", err)
+		log.Fatalln(fmt.Sprintf("error reading template [%s]:", path.Clean(templateFilePath)), err)
 	}
 
 	templateYAML, err := yaml.Parse(templateFilePath, templateFile)
 	if err != nil {
-		log.Fatalln("error parsing template:", err)
+		log.Fatalln(fmt.Sprintf("error parsing template [%s]:", path.Clean(templateFilePath)), err)
 	}
 
 	stubs := []yaml.Node{}
@@ -75,12 +76,12 @@ func merge(templateFilePath string, stubFilePaths []string) {
 	for _, stubFilePath := range stubFilePaths {
 		stubFile, err := ioutil.ReadFile(stubFilePath)
 		if err != nil {
-			log.Fatalln("error reading stub:", err)
+			log.Fatalln(fmt.Sprintf("error reading stub [%s]:", path.Clean(stubFilePath)), err)
 		}
 
 		stubYAML, err := yaml.Parse(stubFilePath, stubFile)
 		if err != nil {
-			log.Fatalln("error parsing stub:", err)
+			log.Fatalln(fmt.Sprintf("error parsing stub [%s]:", path.Clean(stubFilePath)), err)
 		}
 
 		stubs = append(stubs, stubYAML)
@@ -102,22 +103,22 @@ func merge(templateFilePath string, stubFilePaths []string) {
 func diff(aFilePath, bFilePath string, separator string) {
 	aFile, err := ioutil.ReadFile(aFilePath)
 	if err != nil {
-		log.Fatalln("error reading a:", err)
+		log.Fatalln(fmt.Sprintf("error reading a [%s]:", path.Clean(aFilePath)), err)
 	}
 
 	aYAML, err := yaml.Parse(aFilePath, aFile)
 	if err != nil {
-		log.Fatalln("error parsing a:", err)
+		log.Fatalln(fmt.Sprintf("error parsing a [%s]:", path.Clean(aFilePath)), err)
 	}
 
 	bFile, err := ioutil.ReadFile(bFilePath)
 	if err != nil {
-		log.Fatalln("error reading b:", err)
+		log.Fatalln(fmt.Sprintf("error reading b [%s]:", path.Clean(bFilePath)), err)
 	}
 
 	bYAML, err := yaml.Parse(bFilePath, bFile)
 	if err != nil {
-		log.Fatalln("error parsing b:", err)
+		log.Fatalln(fmt.Sprintf("error parsing b [%s]:", path.Clean(bFilePath)), err)
 	}
 
 	diffs := compare.Compare(aYAML, bYAML)


### PR DESCRIPTION
- Fixed old cover repo
- Added stub file path to the errors for diff & merge
- Cleaning the path

The errors now look like this:
2015/02/19 10:55:12 error parsing stub [../diego-release/templates/jobs.yml]: yaml: [while scanning a simple key] could not find expected ':' at line 410, column 11