### PR TITLE
[ci] build step & pipeline example for spiff into docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tags
 *.coverprofile
+pipeline.*.yml

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,3 @@
+FROM progrium/busybox
+
+ADD spiff /bin/spiff

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export GOPATH=$PWD/gopath
+export PATH=$GOPATH/bin:$PATH
+
+cd gopath/src/github.com/cloudfoundry-incubator/spiff
+export GOPATH=${PWD}/Godeps/_workspace:$GOPATH
+export PATH=${PWD}/Godeps/_workspace/bin:$PATH
+
+go build -o ci/spiff .

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -1,0 +1,10 @@
+---
+platform: linux
+image: docker:///concourse/static-golang
+
+inputs:
+  - name: spiff
+    path: gopath/src/github.com/cloudfoundry-incubator/spiff
+
+run:
+  path: gopath/src/github.com/cloudfoundry-incubator/spiff/ci/build.sh

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,0 +1,25 @@
+---
+jobs:
+- name: job-publish
+  public: true
+  serial: true
+  plan:
+  - get: spiff
+  - task: build-spiff
+    file: spiff/build.yml
+  - put: docker-image
+    params:
+      build: build-spiff/gopath/src/github.com/cloudfoundry-incubator/spiff
+resources:
+- name: spiff
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry-incubator/spiff.git
+    branch: ci
+- name: docker-image
+  type: docker-image
+  source:
+    repository: {{ docker_username }}/spiff
+    email: {{ docker_email }}
+    username: {{ docker_username }}
+    password: {{ docker_password }}


### PR DESCRIPTION
`ci/pipeline.yml` is an example concourse pipeline to compile `spiff` for linux;
then bundle into a busybox image and push to Docker Hub.

![job](http://cl.ly/image/0i0M021S2p3Q/publish_spiff_docker_image.png)

https://registry.hub.docker.com/u/drnic/spiff/ is an example.