### PR TITLE
Allow concatenation of Strings and Ints

### DIFF
--- a/dynaml/concatenation.go
+++ b/dynaml/concatenation.go
@@ -2,6 +2,7 @@ package dynaml
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
@@ -22,10 +23,9 @@ func (e ConcatenationExpr) Evaluate(binding Binding) (yaml.Node, bool) {
 		return nil, false
 	}
 
-	astring, aok := a.Value().(string)
-	bstring, bok := b.Value().(string)
-	if aok && bok {
-		return node(astring + bstring), true
+	val, ok := concatenateStringAndInt(a, b)
+	if ok {
+		return node(val), true
 	}
 
 	alist, aok := a.Value().([]yaml.Node)
@@ -39,4 +39,21 @@ func (e ConcatenationExpr) Evaluate(binding Binding) (yaml.Node, bool) {
 
 func (e ConcatenationExpr) String() string {
 	return fmt.Sprintf("%s %s", e.A, e.B)
+}
+
+func concatenateStringAndInt(a yaml.Node, b yaml.Node) (string, bool) {
+	aString, aOk := a.Value().(string)
+	if aOk {
+		bString, bOk := b.Value().(string)
+		if bOk {
+			return aString + bString, true
+		} else {
+			bInt, bOk := b.Value().(int64)
+			if bOk {
+				return aString + strconv.FormatInt(bInt, 10), true
+			}
+		}
+	}
+
+	return "", false
 }

--- a/dynaml/concatenation_test.go
+++ b/dynaml/concatenation_test.go
@@ -21,14 +21,38 @@ var _ = Describe("concatenation", func() {
 		})
 
 		Context("and the right-hand side is NOT a string", func() {
-			It("fails", func() {
-				expr := ConcatenationExpr{
-					StringExpr{"two"},
-					IntegerExpr{42},
-				}
+			Context("and the right-hand side is an integer", func() {
+				It("concatenates both as strings", func() {
+					expr := ConcatenationExpr{
+						StringExpr{"two"},
+						IntegerExpr{42},
+					}
 
-				Expect(expr).To(FailToEvaluate(FakeBinding{}))
+					Expect(expr).To(EvaluateAs("two42", FakeBinding{}))
+				})
 			})
+
+			Context("and the right-hand side is not an integer", func() {
+				It("fails", func() {
+					expr := ConcatenationExpr{
+						StringExpr{"two"},
+						ListExpr{[]Expression{StringExpr{"one"}}},
+					}
+
+					Expect(expr).To(FailToEvaluate(FakeBinding{}))
+				})
+			})
+		})
+	})
+
+	Context("when the left-hand side is a int", func() {
+		It("fails to concatenate with a string", func() {
+			expr := ConcatenationExpr{
+				IntegerExpr{42},
+				StringExpr{"one"},
+			}
+
+			Expect(expr).To(FailToEvaluate(FakeBinding{}))
 		})
 	})
 

--- a/yaml/node_test.go
+++ b/yaml/node_test.go
@@ -48,7 +48,6 @@ var _ = Describe("Node", func() {
 	})
 
 	Describe("EquivalentToNode", func() {
-
 		Context("Node value is an string", func() {
 			var (
 				subjectValue = "hello world"
@@ -209,7 +208,5 @@ var _ = Describe("Node", func() {
 				Expect(subject.EquivalentToNode(object)).To(BeFalse())
 			})
 		})
-
 	})
-
 })


### PR DESCRIPTION
* Do not allow concatenation of two ints
* Often times concatenating a int with a string is reasonable
  i,e: http://example.com:4000 where http://example.com: is a string and 4000 is a port