### PR TITLE
fix spiff build failure

### DIFF
--- a/yaml/node.go
+++ b/yaml/node.go
@@ -39,8 +39,8 @@ func (n AnnotatedNode) SourceName() string {
 	return n.sourceName
 }
 
-func (n AnnotatedNode) MarshalYAML() (string, interface{}) {
-	return "", n.Value()
+func (n AnnotatedNode) MarshalYAML() (string, interface{}, error) {
+	return "", n.Value(), nil
 }
 
 func (n AnnotatedNode) EquivalentToNode(o Node) bool {

--- a/yaml/node_test.go
+++ b/yaml/node_test.go
@@ -41,7 +41,8 @@ var _ = Describe("Node", func() {
 			subjectSourceName := "source/path"
 			subject := NewNode(subjectValue, subjectSourceName)
 
-			tag, value := subject.MarshalYAML()
+			tag, value, err := subject.MarshalYAML()
+			Expect(err).NotTo(HaveOccurred())
 			Expect(tag).To(Equal(""))
 			Expect(value).To(Equal(subjectValue))
 		})


### PR DESCRIPTION
this fixes the build failure introduced by recent commit in [candiedyaml] (https://github.com/cloudfoundry-incubator/candiedyaml/commit/29b4d9cda9fd156adea631d790c95d37ee6ab8e6#diff-e214241880c7c5dc058ccee5f600a351 )

```
./../gopkg/src/github.com/cloudfoundry-incubator/spiff/yaml/node.go:23: cannot use AnnotatedNode literal (type AnnotatedNode) as type Node in return argument:
        AnnotatedNode does not implement Node (wrong type for MarshalYAML method)
                have MarshalYAML() (string, interface {})
                want MarshalYAML() (string, interface {}, error)
../../gopkg/src/github.com/cloudfoundry-incubator/spiff/yaml/parser.go:49: cannot use AnnotatedNode literal (type AnnotatedNode) as type Node in return argument:
        AnnotatedNode does not implement Node (wrong type for MarshalYAML method)
                have MarshalYAML() (string, interface {})
                want MarshalYAML() (string, interface {}, error)
../../gopkg/src/github.com/cloudfoundry-incubator/spiff/yaml/parser.go:63: cannot use AnnotatedNode literal (type AnnotatedNode) as type Node in return argument:
        AnnotatedNode does not implement Node (wrong type for MarshalYAML method)
                have MarshalYAML() (string, interface {})
                want MarshalYAML() (string, interface {}, error)
../../gopkg/src/github.com/cloudfoundry-incubator/spiff/yaml/parser.go:66: cannot use AnnotatedNode literal (type AnnotatedNode) as type Node in return argument:
        AnnotatedNode does not implement Node (wrong type for MarshalYAML method)
                have MarshalYAML() (string, interface {})
                want MarshalYAML() (string, interface {}, error)

```
