### PR TITLE
fix for referencing merged list/map entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Contents:
 		- [(( map[map|x,y|->x ":" port] ))](#-mapmapxy-x--port-) 
 	- [Operation Priorities](#operation-priorities)
 - [Structural Auto-Merge](#structural-auto-merge)
+- [Useful to Know](#useful-to-know)
 - [Error Reporting](#error-reporting)
 
 
@@ -1129,7 +1130,7 @@ list:
 
 - _Expressions are subject to be overridden as a whole_
   
-  A consequence of the behaviour describd above is that nodes described by an expession are basically overridden by a complete merged structure, instead of doing a deep merge with the structues resulting from the expression evaluation.
+  A consequence of the behaviour described above is that nodes described by an expession are basically overridden by a complete merged structure, instead of doing a deep merge with the structues resulting from the expression evaluation.
 
   For example, merging
  
@@ -1172,6 +1173,38 @@ list:
   people:
     - alice: 24
 	- bob: 24
+  ```
+
+- _Nested merge expressions use implied redirections_
+
+  `merge` expressions implicity use a redirection implied by an outer redirecting merge. In the following
+  example
+
+  ```yaml
+  meta:
+    <<: (( merge deployments.cf ))
+    properties:
+      <<: (( merge ))
+      alice: 42
+  ```
+  the merge expression in `meta.properties` is implicity redirected to the path `deployments.cf.properties`
+  implied by the outer redirecting `merge`. Therefore merging with
+
+  ```yaml
+  deployments:
+    cf:
+      properties:
+	    alice: 24
+	    bob: 42
+  ```
+
+  yields
+
+  ```yaml
+  meta:
+    properties:
+      alice: 24
+	  bob: 42
   ```
 
 # Error Reporting

--- a/dynaml/parser_test.go
+++ b/dynaml/parser_test.go
@@ -372,7 +372,7 @@ var _ = Describe("parsing", func() {
 })
 
 func parsesAs(source string, expr Expression, path ...string) {
-	parsed, err := Parse(source, path)
+	parsed, err := Parse(source, path, path)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(parsed).To(Equal(expr))
 }

--- a/dynaml/reference.go
+++ b/dynaml/reference.go
@@ -33,15 +33,18 @@ func (e ReferenceExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, boo
 			return nil, info, false
 		}
 
-		switch step.Value().(type) {
-		case Expression:
+		if !isLocallyResolved(step) {
+			debug.Debug("  unresoved\n")
 			return node(e), info, true
 		}
 	}
 
 	if !isResolved(step) {
+		debug.Debug("  unresoved\n")
 		return node(e), info, true
 	}
+
+	debug.Debug("reference %v -> %+v\n", e.Path, step)
 	return yaml.ReferencedNode(step), info, true
 }
 

--- a/dynaml/unresolved_check.go
+++ b/dynaml/unresolved_check.go
@@ -105,6 +105,24 @@ func addContext(context []string, step string) []string {
 	return append(dup, step)
 }
 
+func isLocallyResolved(node yaml.Node) bool {
+	switch v := node.Value().(type) {
+	case Expression:
+		return false
+	case map[string]yaml.Node:
+		if !yaml.IsMapResolved(v) {
+			return false
+		}
+	case []yaml.Node:
+		if !yaml.IsListResolved(v) {
+			return false
+		}
+	default:
+	}
+
+	return true
+}
+
 func isResolved(node yaml.Node) bool {
 	if node == nil {
 		return true

--- a/flow/environment.go
+++ b/flow/environment.go
@@ -20,7 +20,7 @@ func (e Environment) FindFromRoot(path []string) (yaml.Node, bool) {
 		return nil, false
 	}
 
-	return yaml.Find(yaml.NewNode(e.Scope[0], "scope"), path...)
+	return yaml.FindR(true, yaml.NewNode(e.Scope[0], "scope"), path...)
 }
 
 func (e Environment) FindReference(path []string) (yaml.Node, bool) {
@@ -29,7 +29,7 @@ func (e Environment) FindReference(path []string) (yaml.Node, bool) {
 		return nil, false
 	}
 
-	return yaml.Find(root, path[1:]...)
+	return yaml.FindR(true, root, path[1:]...)
 }
 
 func (e Environment) FindInStubs(path []string) (yaml.Node, bool) {

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -297,7 +297,7 @@ func processMerges(orig yaml.Node, root []yaml.Node, env Environment) ([]yaml.No
 			continue
 		}
 
-		inlineNode, ok := yaml.UnresolvedMerge(val)
+		inlineNode, ok := yaml.UnresolvedListEntryMerge(val)
 		if ok {
 			debug.Debug("*** %+v\n", inlineNode.Value())
 			_, initial := inlineNode.Value().(string)
@@ -385,9 +385,9 @@ func newEntries(a []yaml.Node, b []yaml.Node, keyName string) []yaml.Node {
 	added := []yaml.Node{}
 
 	for _, val := range a {
-		name, ok := yaml.FindString(val, keyName)
+		name, ok := yaml.FindStringR(true, val, keyName)
 		if ok {
-			_, found := yaml.Find(old, name) // TODO
+			_, found := yaml.FindR(true, old, name) // TODO
 			if found {
 				continue
 			}

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -265,7 +265,7 @@ func flowString(root yaml.Node, env Environment) yaml.Node {
 		return root
 	}
 	debug.Debug("dynaml: %v: %s\n", env.Path, *sub)
-	expr, err := dynaml.Parse(*sub, env.Path)
+	expr, err := dynaml.Parse(*sub, env.Path, env.StubPath)
 	if err != nil {
 		return root
 	}


### PR DESCRIPTION
Unfortunately I found a bug in my new merge handling in combination with reference evaluation.
I added the tests for those cases and provide the fix.

Entries overridden by an inline merge should be referenced with the
overridden value, but so far the original value is used

```yaml
---
foo:
  <<: (( merge ))
  bar: 42
ref:
  bar: (( foo.bar ))
```
merged with
```yaml
---
foo:
  bob: added!
  bar: overridden
```
should resolve ref to `overridden` not `42`.

problem occurs for all variants of inline merges