### PR TITLE
fix for defaulted static_ips based on expressions

### DIFF
--- a/dynaml/auto_test.go
+++ b/dynaml/auto_test.go
@@ -14,6 +14,7 @@ var _ = Describe("autos", func() {
 		It("sums up the instances of the jobs in the pool", func() {
 			binding := FakeBinding{
 				FoundFromRoot: map[string]yaml.Node{
+					"": node("dummy"),
 					"jobs": parseYAML(`
 - name: some_job
   resource_pool: some_pool
@@ -35,6 +36,7 @@ var _ = Describe("autos", func() {
 			It("returns nil", func() {
 				binding := FakeBinding{
 					FoundFromRoot: map[string]yaml.Node{
+						"": node("dummy"),
 						"jobs": parseYAML(`
 - name: some_job
   resource_pool: some_pool

--- a/dynaml/call.go
+++ b/dynaml/call.go
@@ -47,6 +47,9 @@ func (e CallExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 		return nil, info, false
 	}
 
+	if ok && result == nil {
+		return node(e), info, true
+	}
 	return result, sub.Join(info), ok
 }
 

--- a/dynaml/call_test.go
+++ b/dynaml/call_test.go
@@ -7,6 +7,21 @@ import (
 	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
+func newNetworkFakeBinding(subnets yaml.Node, instances interface{}) Binding {
+	return FakeBinding{
+		FoundReferences: map[string]yaml.Node{
+			"name":      node("cf1"),
+			"instances": node(instances),
+		},
+		FoundFromRoot: map[string]yaml.Node{
+			"":                     node("dummy"),
+			"networks":             node("dummy"),
+			"networks.cf1":         node("dummy"),
+			"networks.cf1.subnets": subnets,
+		},
+	}
+}
+
 var _ = Describe("calls", func() {
 	Describe("CIDR functions", func() {
 		It("determines minimal IP", func() {
@@ -158,16 +173,7 @@ var _ = Describe("calls", func() {
 - static:
     - 10.10.16.11 - 10.10.16.254
 `)
-
-			binding := FakeBinding{
-				FoundReferences: map[string]yaml.Node{
-					"name":      node("cf1"),
-					"instances": node(2),
-				},
-				FoundFromRoot: map[string]yaml.Node{
-					"networks.cf1.subnets": subnets,
-				},
-			}
+			binding := newNetworkFakeBinding(subnets, 2)
 
 			Expect(expr).To(
 				EvaluateAs(
@@ -183,15 +189,7 @@ var _ = Describe("calls", func() {
     - 10.10.16.10 - 10.10.16.254
 `)
 
-			binding := FakeBinding{
-				FoundReferences: map[string]yaml.Node{
-					"name":      node("cf1"),
-					"instances": node(1),
-				},
-				FoundFromRoot: map[string]yaml.Node{
-					"networks.cf1.subnets": subnets,
-				},
-			}
+			binding := newNetworkFakeBinding(subnets, 1)
 
 			Expect(expr).To(
 				EvaluateAs(
@@ -208,15 +206,7 @@ var _ = Describe("calls", func() {
     - 10.10.16.10 - 10.10.16.254
 `)
 
-				binding := FakeBinding{
-					FoundReferences: map[string]yaml.Node{
-						"name":      node("cf1"),
-						"instances": node(MergeExpr{}),
-					},
-					FoundFromRoot: map[string]yaml.Node{
-						"networks.cf1.subnets": subnets,
-					},
-				}
+				binding := newNetworkFakeBinding(subnets, MergeExpr{})
 
 				Expect(expr).To(FailToEvaluate(binding))
 			})
@@ -229,15 +219,7 @@ var _ = Describe("calls", func() {
     - 10.10.16.10 - 10.10.16.32
 `)
 
-				binding := FakeBinding{
-					FoundReferences: map[string]yaml.Node{
-						"name":      node("cf1"),
-						"instances": node(42),
-					},
-					FoundFromRoot: map[string]yaml.Node{
-						"networks.cf1.subnets": subnets,
-					},
-				}
+				binding := newNetworkFakeBinding(subnets, 42)
 
 				Expect(expr).To(FailToEvaluate(binding))
 			})
@@ -261,15 +243,7 @@ var _ = Describe("calls", func() {
 					},
 				}
 
-				binding := FakeBinding{
-					FoundReferences: map[string]yaml.Node{
-						"name":      node("cf1"),
-						"instances": node(3),
-					},
-					FoundFromRoot: map[string]yaml.Node{
-						"networks.cf1.subnets": subnets,
-					},
-				}
+				binding := newNetworkFakeBinding(subnets, 3)
 
 				Expect(expr).To(
 					EvaluateAs(

--- a/dynaml/concatenation.go
+++ b/dynaml/concatenation.go
@@ -57,6 +57,8 @@ func (e ConcatenationExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo,
 	switch b.(type) {
 	case []yaml.Node:
 		return node(append(alist, b.([]yaml.Node)...)), info, true
+	case nil:
+		return node(a), info, true
 	default:
 		return node(append(alist, node(b))), info, true
 	}

--- a/dynaml/concatenation_test.go
+++ b/dynaml/concatenation_test.go
@@ -106,6 +106,22 @@ var _ = Describe("concatenation", func() {
 					Expect(expr).To(EvaluateAs([]yaml.Node{node("two"), node(map[string]yaml.Node{"bar": node(42)})}, binding))
 				})
 			})
+
+			Context("and the right-hand side is nil", func() {
+				It("keeps the lists", func() {
+					expr := ConcatenationExpr{
+						ListExpr{[]Expression{StringExpr{"two"}}},
+						NilExpr{},
+					}
+
+					binding := FakeBinding{
+						FoundReferences: map[string]yaml.Node{
+							"foo": node(map[string]yaml.Node{"bar": node(42)}),
+						},
+					}
+					Expect(expr).To(EvaluateAs([]yaml.Node{node("two")}, binding))
+				})
+			})
 		})
 	})
 })

--- a/dynaml/exec.go
+++ b/dynaml/exec.go
@@ -83,7 +83,7 @@ func getArg(i int, value interface{}) (string, bool) {
 	case int64:
 		return strconv.FormatInt(value.(int64), 10), true
 	default:
-		if i == 0 {
+		if i == 0 || value == nil {
 			return "", false
 		}
 		yaml, err := candiedyaml.Marshal(node(value))

--- a/dynaml/fake_binding_helper_test.go
+++ b/dynaml/fake_binding_helper_test.go
@@ -13,7 +13,11 @@ type FakeBinding struct {
 }
 
 func (c FakeBinding) FindFromRoot(path []string) (yaml.Node, bool) {
-	val, found := c.FoundFromRoot[strings.Join(path, ".")]
+	p := strings.Join(path, ".")
+	if len(path) == 0 {
+		p = ""
+	}
+	val, found := c.FoundFromRoot[p]
 	return val, found
 }
 

--- a/dynaml/join.go
+++ b/dynaml/join.go
@@ -42,6 +42,7 @@ func func_join(arguments []interface{}, binding Binding) (yaml.Node, EvaluationI
 					return nil, info, false
 				}
 			}
+		case nil:
 		default:
 			info.Issue = fmt.Sprintf("argument %d to join must be simple value or list", i)
 			return nil, info, false

--- a/dynaml/unresolved_check.go
+++ b/dynaml/unresolved_check.go
@@ -105,6 +105,14 @@ func addContext(context []string, step string) []string {
 	return append(dup, step)
 }
 
+func isExpression(node yaml.Node) bool {
+	if node == nil {
+		return false
+	}
+	_, ok := node.Value().(Expression)
+	return ok
+}
+
 func isLocallyResolved(node yaml.Node) bool {
 	switch v := node.Value().(type) {
 	case Expression:


### PR DESCRIPTION
Yet another problem with `static_ips` in combination with the `||`expression and expressions used for the implicitly used yaml elements. 

`static_ips` as well as `auto` are not only using their arguments, but also dedicated parts of the
yaml document (the static ip ranges for the network section and the job definition).
If `static_ips` is used together with the `||` operator and an implicitly used value from the network or job
definition is using a dynaml expression, the resulting value is always the default value, because the implementation does not distinuish between a final error situation and an intermediate problem because of  an unresolved node. This becomes relevant with the new expression evaluation.

The calculation of the static ips must be delayed until the indirectly used elements are completely resolved, instead of delivering an error. Therefore the reference evaluation now uses reference expressions, instead of a direct lookup in the yaml document. This provides the opportunity to handle the unresolved case.