### PR TITLE
Dynamic Functions and Templates for spiff

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,12 +676,13 @@ ip: 10.10.10.10
 range: 10.10.10.10-10.11.11.1
 ```
 
-Additionally there are functions working on CIDRs:
+Additionally there are functions working on IPv4 CIDRs:
 
 ```yaml
 cidr: 192.168.0.1/24
 range: (( min_ip(cidr) "-" max_ip(cidr) ))
 next: (( max_ip(cidr) + 1 ))
+num: (( min_ip(cidr) "+" num_ip(cidr) "=" min_ip(cidr) + num_ip(cidr) ))
 ```
 
 yields
@@ -690,6 +691,7 @@ yields
 cidr: 192.168.0.1/24
 range: 192.168.0.0-192.168.0.255
 next: 192.168.1.0
+num: 192.168.0.0+256=192.168.1.0
 ```
 
 ## Functions
@@ -1116,7 +1118,7 @@ The following levels are supported (from low priority to high priority)
 2. White-space separated sequence as concatenation operation (`foo bar`)
 3. `+`, `-`
 4. `*`, `/`, `%`
-5. Grouping `( )`, constants, references (`foo.bar`) and functions (`merge`, `auto`, `lambda`, `map[]`, `join`, `split`, `trim`, `length`, `exec`, `static_ips`, `min_ip`, `max_ip`)
+5. Grouping `( )`, constants, references (`foo.bar`) and functions (`merge`, `auto`, `lambda`, `map[]`, `join`, `split`, `trim`, `length`, `exec`, `static_ips`, `min_ip`, `max_ip`, `num_ip`)
 
 The complete grammar can be found in [dynaml.peg](dynaml/dynaml.peg).
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,13 @@ Contents:
 	- [(( a || b ))](#-a--b-)
 	- [(( 1 + 2 * foo ))](#-1--2--foo-)
 	- [(( "10.10.10.10" - 11 ))](#-10101010---11-)
-	- [(( join( ", ", list) ))](#-join---list-)
-	- [(( split( ",", string) ))](#-split--string-)
-	- [(( trim(string) ))](#-trimstring-)
-	- [(( exec( "command", arg1, arg2) ))](#-exec-command-arg1-arg2-)
-	- [(( static_ips(0, 1, 3) ))](#-static_ips0-1-3-)
+	- [Functions](#functions)
+		- [(( join( ", ", list) ))](#-join---list-)
+		- [(( split( ",", string) ))](#-split--string-)
+		- [(( trim(string) ))](#-trimstring-)
+		- [(( length(list) ))](#-lengthlist-)
+		- [(( exec( "command", arg1, arg2) ))](#-exec-command-arg1-arg2-)
+		- [(( static_ips(0, 1, 3) ))](#-static_ips0-1-3-)
 	- [(( lambda |x|->x ":" port ))](#-lambda-x-x--port-)
 	- [Mappings](#mappings)
 		- [(( map[list|elem|->dynaml-expr] ))](#-maplistelem-dynaml-expr-)
@@ -690,7 +692,18 @@ range: 192.168.0.0-192.168.0.255
 next: 192.168.1.0
 ```
 
-## `(( join( ", ", list) ))`
+## Functions
+
+Dynaml supports a set of predefined functions. A function is generally called like
+
+```yaml
+result: (( functionname(arg, arg, ...) ))
+```
+
+Additional functions may be defined as part of the yaml document using [lambda expressions](#-lambda-x-x--port-). The function name then is either a grouped expression or the path to the node hosting the lambda expression.
+ 
+
+### `(( join( ", ", list) ))`
 
 Join entries of lists or direct values to a single string value using a given separator string. The arguments to join can be dynaml expressions evaluating to lists, whose values again are strings or integers, or string or integer values.
 
@@ -707,7 +720,7 @@ join: (( join(", ", "bob", list, alice, 10) ))
 
 yields the string value `bob, foo, bar, alice, 10` for `join`.
 
-## `(( split( ",", string) ))`
+### `(( split( ",", string) ))`
 
 Split a string for a dedicated separator. The result is a list.
 
@@ -725,7 +738,7 @@ list:
   - ' bob'
 ```
 
-## `(( trim(string) ))`
+### `(( trim(string) ))`
 
 Trim a string or all elements of a list of strings. There is an optional second string argument. It can be used to specify a set of characters that will be cut. The default cut set consists of a space and a tab character.
 
@@ -743,8 +756,29 @@ list:
   - bob
 ```
 
+### `(( length(list) ))`
 
-## `(( exec( "command", arg1, arg2) ))`
+Determine the length of a list, a map or a string value.
+
+e.g.:
+
+```yaml
+list:
+  - alice
+  - bob
+length: (( length(list) ))
+```
+
+yields:
+
+```yaml
+list:
+  - alice
+  - bob
+length: 2
+```
+
+### `(( exec( "command", arg1, arg2) ))`
 
 Execute a command. Arguments can be any dynaml expressions including reference expressions evaluated to lists or maps. Lists or maps are passed as single arguments containing a yaml document with the given fragment.
 
@@ -777,7 +811,7 @@ Alternatively `exec` can be called with a single list argument completely descri
 
 The same command will be executed once, only, even if it is used in multiple expressions.
 
-## `(( static_ips(0, 1, 3) ))`
+### `(( static_ips(0, 1, 3) ))`
 
 Generate a list of static IPs for a job.
 
@@ -1082,7 +1116,7 @@ The following levels are supported (from low priority to high priority)
 2. White-space separated sequence as concatenation operation (`foo bar`)
 3. `+`, `-`
 4. `*`, `/`, `%`
-5. Grouping `( )`, constants, references (`foo.bar`) and functions (`merge`, `auto`, `lambda`, `map[]`, `join`, `split`, `trim`, `exec`, `static_ips`, `min_ip`, `max_ip`)
+5. Grouping `( )`, constants, references (`foo.bar`) and functions (`merge`, `auto`, `lambda`, `map[]`, `join`, `split`, `trim`, `length`, `exec`, `static_ips`, `min_ip`, `max_ip`)
 
 The complete grammar can be found in [dynaml.peg](dynaml/dynaml.peg).
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Contents:
 		- [(( length(list) ))](#-lengthlist-)
 		- [(( defined(foobar) ))](#-definedfoobar-)
 		- [(( exec( "command", arg1, arg2) ))](#-exec-command-arg1-arg2-)
+		- [(( eval( foo "." bar ) ))](#-eval-foo--bar--)
 		- [(( static_ips(0, 1, 3) ))](#-static_ips0-1-3-)
 	- [(( lambda |x|->x ":" port ))](#-lambda-x-x--port-)
 	- [Mappings](#mappings)
@@ -894,6 +895,34 @@ string: a
 Alternatively `exec` can be called with a single list argument completely describing the command line.
 
 The same command will be executed once, only, even if it is used in multiple expressions.
+
+### `(( eval( foo "." bar ) ))`
+
+Evaluate the evaluation result of a string expression again as dynaml expression. This can, for example, be used to realize indirections.
+
+e.g.: the expression in
+
+```yaml
+alice:
+  bob: married
+
+foo: alice
+bar: bob
+
+status: (( eval( foo "." bar ) ))
+```
+
+calculates the path to a field, which is then evaluated again to yield the value of this composed field:
+
+```yaml
+alice:
+  bob: married
+
+foo: alice
+bar: bob
+
+status: married
+```
 
 ### `(( static_ips(0, 1, 3) ))`
 

--- a/README.md
+++ b/README.md
@@ -1088,6 +1088,28 @@ value: (( .fibonacci(5) ))
 
 yields the value `8` for the `value` property.
 
+Inner lambda expressions remember the local binding of outer lambda expressions. This can be used to return functions based an arguments of the outer function.
+
+e.g.:
+
+```yaml
+mult: (( lambda |x|-> lambda |y|-> x * y ))
+mult2: (( .mult(2) ))
+value: (( .mult2(3) ))
+```
+
+yields `6` for property `value`.
+
+If a lambda function is called with less arguments than expected, the result is a new function taking the missing arguments (currying).
+
+e.g.:
+
+```yaml
+mult: (( lambda |x,y|-> x * y ))
+mult2: (( .mult(2) ))
+value: (( .mult2(3) ))
+```
+
 If a complete expression is a lambda expression the keyword `lambda` can be omitted.
 
 ## Mappings

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Contents:
 		- [(( defined(foobar) ))](#-definedfoobar-)
 		- [(( exec( "command", arg1, arg2) ))](#-exec-command-arg1-arg2-)
 		- [(( eval( foo "." bar ) ))](#-eval-foo--bar--)
+		- [(( read("file.yml") ))](#-readfileyml-)
 		- [(( static_ips(0, 1, 3) ))](#-static_ips0-1-3-)
 	- [(( lambda |x|->x ":" port ))](#-lambda-x-x--port-)
 	- [Mappings](#mappings)
@@ -929,6 +930,20 @@ bar: bob
 
 status: married
 ```
+
+### `(( read("file.yml") ))` 
+
+Read a file and return its content. There is support for two content types: `yaml` files and `text` files.
+If the file suffix is `.yml`, by default the yaml type is used. An optional second parameter can be used
+to explicitly specifiy the desired return type: `yaml` or `text`.
+
+#### yaml documents
+A yaml document will be parsed and the tree is returned. The  elements of the tree can be accessed by regular dynaml expressions.
+
+Additionally the yaml file may again contain dynaml expressions. All included dynaml expressions will be evaluated in the context of the reading expression. This means that the same file included at different places in a yaml document may result in different sub trees, depending on the used dynaml expressions. 
+
+#### text documents
+A text document will be returned as single string.
 
 ### `(( static_ips(0, 1, 3) ))`
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Contents:
 	- [(( a > 1 ? foo :bar ))](#-a--1--foo-bar-)
 	- [(( 5 -or 6 ))](#-5--or-6-)
 	- [Functions](#functions)
+		- [(( format( "%s %d", alice, 25) ))](#-format-s-d-alice-25-)
 		- [(( join( ", ", list) ))](#-join---list-)
 		- [(( split( ",", string) ))](#-split--string-)
 		- [(( trim(string) ))](#-trimstring-)
@@ -763,6 +764,10 @@ result: (( functionname(arg, arg, ...) ))
 
 Additional functions may be defined as part of the yaml document using [lambda expressions](#-lambda-x-x--port-). The function name then is either a grouped expression or the path to the node hosting the lambda expression.
  
+### `(( format( "%s %d", alice, 25) ))`
+
+Format a string based on arguments given by dynaml expressions. There is a second flavor of this function: `error` formats an error message and sets the evaluation to failed.
+  
 
 ### `(( join( ", ", list) ))`
 

--- a/README.md
+++ b/README.md
@@ -747,11 +747,11 @@ The operators `-or` and `-and` can be used to combine comparison operators to co
 
 **Remark:**
 
-The more traditional operator symbol `||` (and `&&`) cannot be used here, because the operator `||` has already exists in dynam with a different semantic, that does not work for logical operations. The expression `false || true` evaluates to `false`, because it yields the first operand, if it is defined, regardless of its value. To be as compatible as possible this cannot be changed and the bare symbols `or` and `and` cannot be be used, because this would invalidate the concatenation of references with such names. 
+The more traditional operator symbol `||` (and `&&`) cannot be used here, because the operator `||` already exists in dynam with a different semantic, that does not hold for logical operations. The expression `false || true` evaluates to `false`, because it yields the first operand, if it is defined, regardless of its value. To be as compatible as possible this cannot be changed and the bare symbols `or` and `and` cannot be be used, because this would invalidate the concatenation of references with such names. 
 
 ## `(( 5 -or 6 ))`
 
-If both sides of an `-or` or `-and` operator evaluates to an integer value, a bit-wise operation is executed and the result is again an integer. Therefore the expression `5 -or 6` evaluates to `7`.
+If both sides of an `-or` or `-and` operator evaluate to integer values, a bit-wise operation is executed and the result is again an integer. Therefore the expression `5 -or 6` evaluates to `7`.
 
 ## Functions
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Contents:
 		- [(( defined(foobar) ))](#-definedfoobar-)
 		- [(( exec( "command", arg1, arg2) ))](#-exec-command-arg1-arg2-)
 		- [(( eval( foo "." bar ) ))](#-eval-foo--bar--)
+		- [(( env( "HOME" ) ))](#-env-HOME--)
 		- [(( read("file.yml") ))](#-readfileyml-)
 		- [(( static_ips(0, 1, 3) ))](#-static_ips0-1-3-)
 	- [(( lambda |x|->x ":" port ))](#-lambda-x-x--port-)
@@ -931,6 +932,12 @@ bar: bob
 status: married
 ```
 
+### `(( env( "HOME" ) ))`
+
+Read the value of an environment variable whose name is given as dynaml expression. If the environment variable is not set the evaluation fails.
+
+In a second flavor the function `env` accepts multiple arguments and/or list arguments, which are joined to a single list. Every entry in this list is used as name of an environment variable and the result of the function is a map of the given given variables as yaml element. Hereby non-existent environment variables are omitted.
+
 ### `(( read("file.yml") ))` 
 
 Read a file and return its content. There is support for two content types: `yaml` files and `text` files.
@@ -1490,7 +1497,7 @@ utils:
       subnets:
       - range: (( b "/" .network.size ))
         reserved: (( [] lower upper ))
-        static_ips:
+        static:
           - (( first " - " first + s - 1 ))
 ```
 
@@ -1511,7 +1518,7 @@ networks:
     reserved:
     - 10.0.0.0 - 10.0.0.255
     - 10.0.2.0 - 10.0.255.255
-    static_ips:
+    static:
     - 10.0.1.0 - 10.0.1.29
 - name: cf2
   subnets:
@@ -1519,7 +1526,7 @@ networks:
     reserved:
     - 10.1.0.0 - 10.1.0.255
     - 10.1.2.0 - 10.1.255.255
-    static_ips:
+    static:
     - 10.1.1.0 - 10.1.1.29
 ```
 
@@ -1541,14 +1548,14 @@ networks:
   - range: 10.0.0.0/16
     reserved:
     - 10.0.1.0 - 10.0.255.255
-    static_ips:
+    static:
     - 10.0.0.2 - 10.0.0.31
 - name: cf2
   subnets:
   - range: 10.1.0.0/16
     reserved:
     - 10.1.1.0 - 10.1.255.255
-    static_ips:
+    static:
     - 10.1.0.2 - 10.1.0.31
 ```
 
@@ -1572,14 +1579,14 @@ networks:
   - range: 10.0.0.0/17
     reserved:
     - 10.0.0.128 - 10.0.127.255
-    static_ips:
+    static:
     - 10.0.0.2 - 10.0.0.31
 - name: cf2
   subnets:
   - range: 10.0.128.0/17
     reserved:
     - 10.0.128.128 - 10.0.255.255
-    static_ips:
+    static:
     - 10.0.128.2 - 10.0.128.31
 ```
 

--- a/dynaml/addition.go
+++ b/dynaml/addition.go
@@ -40,9 +40,9 @@ func (e AdditionExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool
 		if ip != nil {
 			return node(IPAdd(ip, bint).String()), info, true
 		}
-		info.Issue = "string argument for PLUS must be an IP address"
+		info.Issue = yaml.NewIssue("string argument for PLUS must be an IP address")
 	} else {
-		info.Issue = "first argument of PLUS must be IP address or integer"
+		info.Issue = yaml.NewIssue("first argument of PLUS must be IP address or integer")
 	}
 	return nil, info, false
 }

--- a/dynaml/addition.go
+++ b/dynaml/addition.go
@@ -12,7 +12,7 @@ type AdditionExpr struct {
 	B Expression
 }
 
-func (e AdditionExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e AdditionExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 	resolved := true
 
 	a, info, ok := ResolveExpressionOrPushEvaluation(&e.A, &resolved, nil, binding)
@@ -26,19 +26,19 @@ func (e AdditionExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool
 	}
 
 	if !resolved {
-		return node(e), info, true
+		return e, info, true
 	}
 
 	aint, ok := a.(int64)
 	if ok {
-		return node(aint + bint), info, true
+		return aint + bint, info, true
 	}
 
 	str, ok := a.(string)
 	if ok {
 		ip := net.ParseIP(str)
 		if ip != nil {
-			return node(IPAdd(ip, bint).String()), info, true
+			return IPAdd(ip, bint).String(), info, true
 		}
 		info.Issue = yaml.NewIssue("string argument for PLUS must be an IP address")
 	} else {

--- a/dynaml/auto.go
+++ b/dynaml/auto.go
@@ -18,7 +18,7 @@ func (e AutoExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 	if len(e.Path) == 3 && e.Path[0] == "resource_pools" && e.Path[2] == "size" {
 		jobs, info, found := refJobs.Evaluate(binding)
 		if !found {
-			info.Issue = "no jobs found"
+			info.Issue = yaml.NewIssue("no jobs found")
 			return nil, info, false
 		}
 
@@ -27,7 +27,7 @@ func (e AutoExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 		}
 		jobsList, ok := jobs.Value().([]yaml.Node)
 		if !ok {
-			info.Issue = "jobs must be a list"
+			info.Issue = yaml.NewIssue("jobs must be a list")
 			return nil, info, false
 		}
 
@@ -54,7 +54,7 @@ func (e AutoExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 		return node(size), info, true
 	}
 
-	info.Issue = "auto only allowed for size entry in resource pools"
+	info.Issue = yaml.NewIssue("auto only allowed for size entry in resource pools")
 	return nil, info, false
 }
 

--- a/dynaml/auto.go
+++ b/dynaml/auto.go
@@ -12,7 +12,7 @@ type AutoExpr struct {
 	Path []string
 }
 
-func (e AutoExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e AutoExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 	info := DefaultInfo()
 
 	if len(e.Path) == 3 && e.Path[0] == "resource_pools" && e.Path[2] == "size" {
@@ -22,10 +22,10 @@ func (e AutoExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 			return nil, info, false
 		}
 
-		if !isResolved(jobs) {
-			return node(e), info, true
+		if !isResolvedValue(jobs) {
+			return e, info, true
 		}
-		jobsList, ok := jobs.Value().([]yaml.Node)
+		jobsList, ok := jobs.([]yaml.Node)
 		if !ok {
 			info.Issue = yaml.NewIssue("jobs must be a list")
 			return nil, info, false
@@ -51,7 +51,7 @@ func (e AutoExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 			size += instances
 		}
 
-		return node(size), info, true
+		return size, info, true
 	}
 
 	info.Issue = yaml.NewIssue("auto only allowed for size entry in resource pools")

--- a/dynaml/auto_test.go
+++ b/dynaml/auto_test.go
@@ -14,7 +14,7 @@ var _ = Describe("autos", func() {
 		It("sums up the instances of the jobs in the pool", func() {
 			binding := FakeBinding{
 				FoundFromRoot: map[string]yaml.Node{
-					"": node("dummy"),
+					"": node("dummy", nil),
 					"jobs": parseYAML(`
 - name: some_job
   resource_pool: some_pool
@@ -36,7 +36,7 @@ var _ = Describe("autos", func() {
 			It("returns nil", func() {
 				binding := FakeBinding{
 					FoundFromRoot: map[string]yaml.Node{
-						"": node("dummy"),
+						"": node("dummy", nil),
 						"jobs": parseYAML(`
 - name: some_job
   resource_pool: some_pool

--- a/dynaml/boolean.go
+++ b/dynaml/boolean.go
@@ -2,16 +2,14 @@ package dynaml
 
 import (
 	"fmt"
-
-	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
 type BooleanExpr struct {
 	Value bool
 }
 
-func (e BooleanExpr) Evaluate(Binding) (yaml.Node, EvaluationInfo, bool) {
-	return node(e.Value), DefaultInfo(), true
+func (e BooleanExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
+	return e.Value, DefaultInfo(), true
 }
 
 func (e BooleanExpr) String() string {

--- a/dynaml/call.go
+++ b/dynaml/call.go
@@ -13,7 +13,7 @@ type CallExpr struct {
 	Arguments []Expression
 }
 
-func (e CallExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e CallExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 	resolved := true
 	funcName := ""
 	var value interface{}
@@ -50,10 +50,10 @@ func (e CallExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 	}
 
 	if !resolved {
-		return node(e), info, true
+		return e, info, true
 	}
 
-	var result yaml.Node
+	var result interface{}
 	var sub EvaluationInfo
 
 	switch funcName {
@@ -103,7 +103,7 @@ func (e CallExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 	}
 
 	if ok && (result == nil || isExpression(result)) {
-		return node(e), sub.Join(info), true
+		return e, sub.Join(info), true
 	}
 	return result, sub.Join(info), ok
 }

--- a/dynaml/call.go
+++ b/dynaml/call.go
@@ -80,6 +80,9 @@ func (e CallExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 	case "max_ip":
 		result, sub, ok = func_maxIP(values, binding)
 
+	case "num_ip":
+		result, sub, ok = func_numIP(values, binding)
+
 	default:
 		info.Issue = fmt.Sprintf("unknown function '%s'", funcName)
 		return nil, info, false

--- a/dynaml/call.go
+++ b/dynaml/call.go
@@ -82,6 +82,12 @@ func (e CallExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 	case "eval":
 		result, sub, ok = func_eval(values, binding)
 
+	case "format":
+		result, sub, ok = func_format(values, binding)
+
+	case "error":
+		result, sub, ok = func_error(values, binding)
+
 	case "min_ip":
 		result, sub, ok = func_minIP(values, binding)
 

--- a/dynaml/call.go
+++ b/dynaml/call.go
@@ -79,6 +79,9 @@ func (e CallExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 	case "exec":
 		result, sub, ok = func_exec(values, binding)
 
+	case "eval":
+		result, sub, ok = func_eval(values, binding)
+
 	case "min_ip":
 		result, sub, ok = func_minIP(values, binding)
 

--- a/dynaml/call.go
+++ b/dynaml/call.go
@@ -68,6 +68,9 @@ func (e CallExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 	case "trim":
 		result, sub, ok = func_trim(values, binding)
 
+	case "length":
+		result, sub, ok = func_length(values, binding)
+
 	case "exec":
 		result, sub, ok = func_exec(values, binding)
 

--- a/dynaml/call.go
+++ b/dynaml/call.go
@@ -62,6 +62,12 @@ func (e CallExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 	case "join":
 		result, sub, ok = func_join(values, binding)
 
+	case "split":
+		result, sub, ok = func_split(values, binding)
+
+	case "trim":
+		result, sub, ok = func_trim(values, binding)
+
 	case "exec":
 		result, sub, ok = func_exec(values, binding)
 

--- a/dynaml/call.go
+++ b/dynaml/call.go
@@ -82,6 +82,9 @@ func (e CallExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) 
 	case "eval":
 		result, sub, ok = func_eval(values, binding)
 
+	case "read":
+		result, sub, ok = func_read(values, binding)
+
 	case "format":
 		result, sub, ok = func_format(values, binding)
 

--- a/dynaml/call.go
+++ b/dynaml/call.go
@@ -28,7 +28,7 @@ func (e CallExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 			_, ok = value.(LambdaValue)
 			if !ok {
 				debug.Debug("function: no string or lambda value: %T\n", value)
-				info.Issue = fmt.Sprintf("function call '%s' requires function name or lambda value", e.Function)
+				info.Issue = yaml.NewIssue("function call '%s' requires function name or lambda value", e.Function)
 			}
 		}
 	}
@@ -89,7 +89,7 @@ func (e CallExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 		result, sub, ok = func_numIP(values, binding)
 
 	default:
-		info.Issue = fmt.Sprintf("unknown function '%s'", funcName)
+		info.Issue = yaml.NewIssue("unknown function '%s'", funcName)
 		return nil, info, false
 	}
 

--- a/dynaml/call.go
+++ b/dynaml/call.go
@@ -82,6 +82,9 @@ func (e CallExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) 
 	case "eval":
 		result, sub, ok = func_eval(values, binding)
 
+	case "env":
+		result, sub, ok = func_env(values, binding)
+
 	case "read":
 		result, sub, ok = func_read(values, binding)
 

--- a/dynaml/call_test.go
+++ b/dynaml/call_test.go
@@ -26,7 +26,7 @@ var _ = Describe("calls", func() {
 	Describe("CIDR functions", func() {
 		It("determines minimal IP", func() {
 			expr := CallExpr{
-				Name: "min_ip",
+				Function: ReferenceExpr{[]string{"min_ip"}},
 				Arguments: []Expression{
 					StringExpr{"192.168.0.1/24"},
 				},
@@ -42,7 +42,7 @@ var _ = Describe("calls", func() {
 
 		It("determines maximal IP", func() {
 			expr := CallExpr{
-				Name: "max_ip",
+				Function: ReferenceExpr{[]string{"max_ip"}},
 				Arguments: []Expression{
 					StringExpr{"192.168.0.1/24"},
 				},
@@ -59,7 +59,7 @@ var _ = Describe("calls", func() {
 
 	Describe("join(\", \"...)", func() {
 		expr := CallExpr{
-			Name: "join",
+			Function: ReferenceExpr{[]string{"join"}},
 			Arguments: []Expression{
 				StringExpr{", "},
 				ReferenceExpr{[]string{"alice"}},
@@ -122,7 +122,7 @@ var _ = Describe("calls", func() {
 
 		It("joins nothing", func() {
 			expr := CallExpr{
-				Name: "join",
+				Function: ReferenceExpr{[]string{"join"}},
 				Arguments: []Expression{
 					StringExpr{", "},
 				},
@@ -138,7 +138,7 @@ var _ = Describe("calls", func() {
 
 		It("fails for missing args", func() {
 			expr := CallExpr{
-				Name:      "join",
+				Function:  ReferenceExpr{[]string{"join"}},
 				Arguments: []Expression{},
 			}
 
@@ -147,7 +147,7 @@ var _ = Describe("calls", func() {
 
 		It("fails for wrong separator type", func() {
 			expr := CallExpr{
-				Name: "join",
+				Function: ReferenceExpr{[]string{"join"}},
 				Arguments: []Expression{
 					ListExpr{[]Expression{IntegerExpr{0}}},
 				},
@@ -159,7 +159,7 @@ var _ = Describe("calls", func() {
 
 	Describe("static_ips(ips...)", func() {
 		expr := CallExpr{
-			Name: "static_ips",
+			Function: ReferenceExpr{[]string{"static_ips"}},
 			Arguments: []Expression{
 				IntegerExpr{0},
 				IntegerExpr{4},
@@ -235,7 +235,7 @@ var _ = Describe("calls", func() {
 `)
 
 				expr := CallExpr{
-					Name: "static_ips",
+					Function: ReferenceExpr{[]string{"static_ips"}},
 					Arguments: []Expression{
 						IntegerExpr{0},
 						IntegerExpr{4},

--- a/dynaml/call_test.go
+++ b/dynaml/call_test.go
@@ -55,6 +55,38 @@ var _ = Describe("calls", func() {
 				),
 			)
 		})
+
+		It("determines number of IPs", func() {
+			expr := CallExpr{
+				Function: ReferenceExpr{[]string{"num_ip"}},
+				Arguments: []Expression{
+					StringExpr{"192.168.0.1/24"},
+				},
+			}
+
+			Expect(expr).To(
+				EvaluateAs(
+					int64(256),
+					FakeBinding{},
+				),
+			)
+		})
+
+		It("determines number of IPs for /22", func() {
+			expr := CallExpr{
+				Function: ReferenceExpr{[]string{"num_ip"}},
+				Arguments: []Expression{
+					StringExpr{"192.168.0.1/22"},
+				},
+			}
+
+			Expect(expr).To(
+				EvaluateAs(
+					int64(1024),
+					FakeBinding{},
+				),
+			)
+		})
 	})
 
 	Describe("join(\", \"...)", func() {

--- a/dynaml/call_test.go
+++ b/dynaml/call_test.go
@@ -10,13 +10,13 @@ import (
 func newNetworkFakeBinding(subnets yaml.Node, instances interface{}) Binding {
 	return FakeBinding{
 		FoundReferences: map[string]yaml.Node{
-			"name":      node("cf1"),
-			"instances": node(instances),
+			"name":      node("cf1", nil),
+			"instances": node(instances, nil),
 		},
 		FoundFromRoot: map[string]yaml.Node{
-			"":                     node("dummy"),
-			"networks":             node("dummy"),
-			"networks.cf1":         node("dummy"),
+			"":                     node("dummy", nil),
+			"networks":             node("dummy", nil),
+			"networks.cf1":         node("dummy", nil),
 			"networks.cf1.subnets": subnets,
 		},
 	}
@@ -102,8 +102,8 @@ var _ = Describe("calls", func() {
 		It("joins string values ", func() {
 			binding := FakeBinding{
 				FoundReferences: map[string]yaml.Node{
-					"alice": node("alice"),
-					"bob":   node("bob"),
+					"alice": node("alice", nil),
+					"bob":   node("bob", nil),
 				},
 			}
 
@@ -118,8 +118,8 @@ var _ = Describe("calls", func() {
 		It("joins int values ", func() {
 			binding := FakeBinding{
 				FoundReferences: map[string]yaml.Node{
-					"alice": node(10),
-					"bob":   node(20),
+					"alice": node(10, nil),
+					"bob":   node(20, nil),
 				},
 			}
 
@@ -140,7 +140,7 @@ var _ = Describe("calls", func() {
 			binding := FakeBinding{
 				FoundReferences: map[string]yaml.Node{
 					"alice": list,
-					"bob":   node(20),
+					"bob":   node(20, nil),
 				},
 			}
 
@@ -209,7 +209,7 @@ var _ = Describe("calls", func() {
 
 			Expect(expr).To(
 				EvaluateAs(
-					[]yaml.Node{node("10.10.16.10"), node("10.10.16.14")},
+					[]yaml.Node{node("10.10.16.10", nil), node("10.10.16.14", nil)},
 					binding,
 				),
 			)
@@ -225,7 +225,7 @@ var _ = Describe("calls", func() {
 
 			Expect(expr).To(
 				EvaluateAs(
-					[]yaml.Node{node("10.10.16.10")},
+					[]yaml.Node{node("10.10.16.10", nil)},
 					binding,
 				),
 			)
@@ -279,7 +279,7 @@ var _ = Describe("calls", func() {
 
 				Expect(expr).To(
 					EvaluateAs(
-						[]yaml.Node{node("10.10.16.10"), node("10.10.16.14"), node("10.10.16.33")},
+						[]yaml.Node{node("10.10.16.10", nil), node("10.10.16.14", nil), node("10.10.16.33", nil)},
 						binding,
 					),
 				)

--- a/dynaml/comparison.go
+++ b/dynaml/comparison.go
@@ -15,7 +15,7 @@ type ComparisonExpr struct {
 	B  Expression
 }
 
-func (e ComparisonExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e ComparisonExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 	resolved := true
 
 	a, info, ok := ResolveExpressionOrPushEvaluation(&e.A, &resolved, nil, binding)
@@ -29,7 +29,7 @@ func (e ComparisonExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bo
 	}
 
 	if !resolved {
-		return node(e), info, true
+		return e, info, true
 	}
 
 	var result bool
@@ -75,7 +75,7 @@ func (e ComparisonExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bo
 	if !ok {
 		return nil, infor, false
 	}
-	return node(result), infor, true
+	return result, infor, true
 }
 
 func (e ComparisonExpr) String() string {

--- a/dynaml/comparison.go
+++ b/dynaml/comparison.go
@@ -51,12 +51,12 @@ func (e ComparisonExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bo
 		var va, vb int64
 		va, ok = a.(int64)
 		if !ok {
-			infor.Issue = fmt.Sprintf("comparision %s only for integers", e.Op)
+			infor.Issue = yaml.NewIssue("comparision %s only for integers", e.Op)
 			break
 		}
 		vb, ok = b.(int64)
 		if !ok {
-			infor.Issue = fmt.Sprintf("comparision %s only for integers", e.Op)
+			infor.Issue = yaml.NewIssue("comparision %s only for integers", e.Op)
 			break
 		}
 		switch e.Op {
@@ -100,7 +100,7 @@ func compareEquals(a, b interface{}) (bool, EvaluationInfo, bool) {
 		case bool:
 			vb = strconv.FormatBool(v)
 		default:
-			info.Issue = "types uncomparable"
+			info.Issue = yaml.NewIssue("types uncomparable")
 			return false, info, false
 		}
 		return va == vb, info, true
@@ -123,7 +123,7 @@ func compareEquals(a, b interface{}) (bool, EvaluationInfo, bool) {
 				vb = 0
 			}
 		default:
-			info.Issue = "types uncomparable"
+			info.Issue = yaml.NewIssue("types uncomparable")
 			return false, info, false
 		}
 		return va == vb, info, true
@@ -135,7 +135,7 @@ func compareEquals(a, b interface{}) (bool, EvaluationInfo, bool) {
 		case LambdaValue:
 			return reflect.DeepEqual(va, v), info, true
 		default:
-			info.Issue = "types uncomparable"
+			info.Issue = yaml.NewIssue("types uncomparable")
 			return false, info, false
 		}
 

--- a/dynaml/comparison.go
+++ b/dynaml/comparison.go
@@ -1,0 +1,174 @@
+package dynaml
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"github.com/cloudfoundry-incubator/spiff/debug"
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+type ComparisonExpr struct {
+	A  Expression
+	Op string
+	B  Expression
+}
+
+func (e ComparisonExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	resolved := true
+
+	a, info, ok := ResolveExpressionOrPushEvaluation(&e.A, &resolved, nil, binding)
+	if !ok {
+		return nil, info, false
+	}
+
+	b, info, ok := ResolveExpressionOrPushEvaluation(&e.B, &resolved, &info, binding)
+	if !ok {
+		return nil, info, false
+	}
+
+	if !resolved {
+		return node(e), info, true
+	}
+
+	var result bool
+	var infor EvaluationInfo
+
+	switch e.Op {
+	case "==":
+		result, infor, ok = compareEquals(a, b)
+	case "!=":
+		result, infor, ok = compareEquals(a, b)
+		result = !result
+	case "<=":
+		fallthrough
+	case "<":
+		fallthrough
+	case ">":
+		fallthrough
+	case ">=":
+		var va, vb int64
+		va, ok = a.(int64)
+		if !ok {
+			infor.Issue = fmt.Sprintf("comparision %s only for integers", e.Op)
+			break
+		}
+		vb, ok = b.(int64)
+		if !ok {
+			infor.Issue = fmt.Sprintf("comparision %s only for integers", e.Op)
+			break
+		}
+		switch e.Op {
+		case "<=":
+			result = va <= vb
+		case "<":
+			result = va < vb
+		case ">":
+			result = va > vb
+		case ">=":
+			result = va >= vb
+		}
+	}
+	infor = info.Join(infor)
+
+	if !ok {
+		return nil, infor, false
+	}
+	return node(result), infor, true
+}
+
+func (e ComparisonExpr) String() string {
+	return fmt.Sprintf("%s %s %s", e.A, e.Op, e.B)
+}
+
+func compareEquals(a, b interface{}) (bool, EvaluationInfo, bool) {
+	info := DefaultInfo()
+
+	debug.Debug("compare a '%#v'\n", a)
+	debug.Debug("compare b '%#v' \n", b)
+	switch va := a.(type) {
+	case string:
+		var vb string
+		switch v := b.(type) {
+		case string:
+			vb = v
+		case int64:
+			vb = strconv.FormatInt(v, 10)
+		case LambdaValue:
+			vb = v.String()
+		case bool:
+			vb = strconv.FormatBool(v)
+		default:
+			info.Issue = "types uncomparable"
+			return false, info, false
+		}
+		return va == vb, info, true
+
+	case int64:
+		var vb int64
+		var err error
+		switch v := b.(type) {
+		case string:
+			vb, err = strconv.ParseInt(v, 10, 64)
+			if err != nil {
+				return false, info, true
+			}
+		case int64:
+			vb = v
+		case bool:
+			if v {
+				vb = 1
+			} else {
+				vb = 0
+			}
+		default:
+			info.Issue = "types uncomparable"
+			return false, info, false
+		}
+		return va == vb, info, true
+
+	case LambdaValue:
+		switch v := b.(type) {
+		case string:
+			return va.String() == v, info, true
+		case LambdaValue:
+			return reflect.DeepEqual(va, v), info, true
+		default:
+			info.Issue = "types uncomparable"
+			return false, info, false
+		}
+
+	case []yaml.Node:
+		vb, ok := b.([]yaml.Node)
+		if !ok || len(va) != len(vb) {
+			debug.Debug("compare list len mismatch")
+			break
+		}
+		for i, v := range vb {
+			result, info, _ := compareEquals(va[i].Value(), v.Value())
+			if !result {
+				debug.Debug(fmt.Sprintf("compare list entry %d mismatch", i))
+				return false, info, true
+			}
+		}
+		return true, info, true
+
+	case map[string]yaml.Node:
+		vb, ok := b.(map[string]yaml.Node)
+		if !ok || len(va) != len(vb) {
+			break
+		}
+
+		for k, v := range vb {
+			result, info, _ := compareEquals(va[k].Value(), v.Value())
+			if !result {
+				return false, info, true
+			}
+		}
+		return true, info, true
+
+	}
+
+	return false, info, true
+}

--- a/dynaml/comparison_test.go
+++ b/dynaml/comparison_test.go
@@ -1,0 +1,57 @@
+package dynaml
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func compareIt(op string, result []bool) {
+	for first := 5; first <= 7; first++ {
+		expected := result[first-5]
+		arg := int64(first)
+		It(fmt.Sprintf("evaluates %d%s6", first, op), func() {
+			expr := ComparisonExpr{
+				IntegerExpr{arg},
+				op,
+				IntegerExpr{6},
+			}
+
+			Expect(expr).To(EvaluateAs(expected, FakeBinding{}))
+		})
+	}
+}
+
+var _ = Describe("comparison operators", func() {
+	Context("<=", func() {
+		compareIt("<=", []bool{true, true, false})
+		compareIt("<", []bool{true, false, false})
+		compareIt(">=", []bool{false, true, true})
+		compareIt(">", []bool{false, false, true})
+		compareIt("==", []bool{false, true, false})
+		compareIt("!=", []bool{true, false, true})
+	})
+
+	Context("when one side fails", func() {
+		It("fails for left side failing", func() {
+			expr := ComparisonExpr{
+				FailingExpr{},
+				"<=",
+				IntegerExpr{6},
+			}
+
+			Expect(expr).To(FailToEvaluate(FakeBinding{}))
+		})
+
+		It("fails for right side failing", func() {
+			expr := ComparisonExpr{
+				IntegerExpr{6},
+				"<=",
+				FailingExpr{},
+			}
+
+			Expect(expr).To(FailToEvaluate(FakeBinding{}))
+		})
+	})
+})

--- a/dynaml/concatenation.go
+++ b/dynaml/concatenation.go
@@ -13,7 +13,7 @@ type ConcatenationExpr struct {
 	B Expression
 }
 
-func (e ConcatenationExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e ConcatenationExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 	resolved := true
 
 	debug.Debug("CONCAT %+v,%+v\n", e.A, e.B)
@@ -32,7 +32,7 @@ func (e ConcatenationExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo,
 
 	if !resolved {
 		debug.Debug("  still unresolved operands\n")
-		return node(e), info, true
+		return e, info, true
 	}
 
 	debug.Debug("CONCAT resolved %+v,%+v\n", a, b)
@@ -40,7 +40,7 @@ func (e ConcatenationExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo,
 	val, ok := concatenateString(a, b)
 	if ok {
 		debug.Debug("CONCAT --> string %+v\n", val)
-		return node(val), info, true
+		return val, info, true
 	}
 
 	alist, aok := a.([]yaml.Node)
@@ -56,11 +56,11 @@ func (e ConcatenationExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo,
 
 	switch b.(type) {
 	case []yaml.Node:
-		return node(append(alist, b.([]yaml.Node)...)), info, true
+		return append(alist, b.([]yaml.Node)...), info, true
 	case nil:
-		return node(a), info, true
+		return a, info, true
 	default:
-		return node(append(alist, node(b))), info, true
+		return append(alist, node(b, info)), info, true
 	}
 }
 

--- a/dynaml/concatenation.go
+++ b/dynaml/concatenation.go
@@ -37,7 +37,7 @@ func (e ConcatenationExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo,
 
 	debug.Debug("CONCAT resolved %+v,%+v\n", a, b)
 
-	val, ok := concatenateStringAndInt(a, b)
+	val, ok := concatenateString(a, b)
 	if ok {
 		debug.Debug("CONCAT --> string %+v\n", val)
 		return node(val), info, true
@@ -68,7 +68,7 @@ func (e ConcatenationExpr) String() string {
 	return fmt.Sprintf("%s %s", e.A, e.B)
 }
 
-func concatenateStringAndInt(a interface{}, b interface{}) (string, bool) {
+func concatenateString(a interface{}, b interface{}) (string, bool) {
 	var aString string
 
 	switch v := a.(type) {
@@ -89,6 +89,8 @@ func concatenateStringAndInt(a interface{}, b interface{}) (string, bool) {
 		return aString + strconv.FormatInt(v, 10), true
 	case bool:
 		return aString + strconv.FormatBool(v), true
+	case LambdaValue:
+		return aString + fmt.Sprintf("%s", v), true
 	default:
 		return "", false
 	}

--- a/dynaml/concatenation.go
+++ b/dynaml/concatenation.go
@@ -47,9 +47,9 @@ func (e ConcatenationExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo,
 	if !aok {
 		switch a.(type) {
 		case map[string]yaml.Node:
-			info.Issue = "first argument must be list or simple value"
+			info.Issue = yaml.NewIssue("first argument must be list or simple value")
 		default:
-			info.Issue = "simple value can only be concatenated with simple values"
+			info.Issue = yaml.NewIssue("simple value can only be concatenated with simple values")
 		}
 		return nil, info, false
 	}

--- a/dynaml/concatenation_test.go
+++ b/dynaml/concatenation_test.go
@@ -64,7 +64,7 @@ var _ = Describe("concatenation", func() {
 					ListExpr{[]Expression{StringExpr{"two"}}},
 				}
 
-				Expect(expr).To(EvaluateAs([]yaml.Node{node("one"), node("two")}, FakeBinding{}))
+				Expect(expr).To(EvaluateAs([]yaml.Node{node("one", nil), node("two", nil)}, FakeBinding{}))
 			})
 		})
 
@@ -76,7 +76,7 @@ var _ = Describe("concatenation", func() {
 						IntegerExpr{42},
 					}
 
-					Expect(expr).To(EvaluateAs([]yaml.Node{node("two"), node(42)}, FakeBinding{}))
+					Expect(expr).To(EvaluateAs([]yaml.Node{node("two", nil), node(42, nil)}, FakeBinding{}))
 				})
 			})
 
@@ -87,7 +87,7 @@ var _ = Describe("concatenation", func() {
 						StringExpr{"one"},
 					}
 
-					Expect(expr).To(EvaluateAs([]yaml.Node{node("two"), node("one")}, FakeBinding{}))
+					Expect(expr).To(EvaluateAs([]yaml.Node{node("two", nil), node("one", nil)}, FakeBinding{}))
 				})
 			})
 
@@ -100,10 +100,10 @@ var _ = Describe("concatenation", func() {
 
 					binding := FakeBinding{
 						FoundReferences: map[string]yaml.Node{
-							"foo": node(map[string]yaml.Node{"bar": node(42)}),
+							"foo": node(map[string]yaml.Node{"bar": node(42, nil)}, nil),
 						},
 					}
-					Expect(expr).To(EvaluateAs([]yaml.Node{node("two"), node(map[string]yaml.Node{"bar": node(42)})}, binding))
+					Expect(expr).To(EvaluateAs([]yaml.Node{node("two", nil), node(map[string]yaml.Node{"bar": node(42, nil)}, nil)}, binding))
 				})
 			})
 
@@ -116,10 +116,10 @@ var _ = Describe("concatenation", func() {
 
 					binding := FakeBinding{
 						FoundReferences: map[string]yaml.Node{
-							"foo": node(map[string]yaml.Node{"bar": node(42)}),
+							"foo": node(map[string]yaml.Node{"bar": node(42, nil)}, nil),
 						},
 					}
-					Expect(expr).To(EvaluateAs([]yaml.Node{node("two")}, binding))
+					Expect(expr).To(EvaluateAs([]yaml.Node{node("two", nil)}, binding))
 				})
 			})
 		})

--- a/dynaml/cond.go
+++ b/dynaml/cond.go
@@ -1,0 +1,58 @@
+package dynaml
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+type CondExpr struct {
+	C Expression
+	T Expression
+	F Expression
+}
+
+func (e CondExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	resolved := true
+	info := DefaultInfo()
+	var result yaml.Node
+
+	a, info, ok := ResolveExpressionOrPushEvaluation(&e.C, &resolved, &info, binding)
+	if !ok {
+		return nil, info, false
+	}
+	if !resolved {
+		return node(e), info, true
+	}
+	if toBool(a) {
+		result, info, ok = e.T.Evaluate(binding)
+	} else {
+		result, info, ok = e.F.Evaluate(binding)
+	}
+	return result, info, ok
+}
+
+func (e CondExpr) String() string {
+	return fmt.Sprintf("%s ? %s : %s", e.C, e.T, e.F)
+}
+
+func toBool(v interface{}) bool {
+	if v == nil {
+		return false
+	}
+
+	switch eff := v.(type) {
+	case bool:
+		return eff
+	case string:
+		return len(eff) > 0
+	case int64:
+		return eff != 0
+	case []yaml.Node:
+		return len(eff) != 0
+	case map[string]yaml.Node:
+		return len(eff) != 0
+	default:
+		return true
+	}
+}

--- a/dynaml/cond.go
+++ b/dynaml/cond.go
@@ -12,17 +12,17 @@ type CondExpr struct {
 	F Expression
 }
 
-func (e CondExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e CondExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 	resolved := true
 	info := DefaultInfo()
-	var result yaml.Node
+	var result interface{}
 
 	a, info, ok := ResolveExpressionOrPushEvaluation(&e.C, &resolved, &info, binding)
 	if !ok {
 		return nil, info, false
 	}
 	if !resolved {
-		return node(e), info, true
+		return e, info, true
 	}
 	if toBool(a) {
 		result, info, ok = e.T.Evaluate(binding)

--- a/dynaml/cond_test.go
+++ b/dynaml/cond_test.go
@@ -99,8 +99,8 @@ var _ = Describe("conditional operator", func() {
 	Context("on map condition", func() {
 		It("returns first if length != 0", func() {
 			mapNode := node(map[string]yaml.Node{
-				"bar": node("alice"),
-			})
+				"bar": node("alice", nil),
+			}, nil)
 			expr := CondExpr{
 				C: ReferenceExpr{[]string{"foo"}},
 				T: IntegerExpr{2},
@@ -111,7 +111,7 @@ var _ = Describe("conditional operator", func() {
 		})
 
 		It("returns second if length == 0", func() {
-			mapNode := node(map[string]yaml.Node{})
+			mapNode := node(map[string]yaml.Node{}, nil)
 			expr := CondExpr{
 				C: ReferenceExpr{[]string{"foo"}},
 				T: IntegerExpr{2},

--- a/dynaml/cond_test.go
+++ b/dynaml/cond_test.go
@@ -1,0 +1,136 @@
+package dynaml
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+var _ = Describe("conditional operator", func() {
+	Context("on boolean condition", func() {
+		It("returns second if false", func() {
+			expr := CondExpr{
+				C: BooleanExpr{false},
+				T: IntegerExpr{2},
+				F: IntegerExpr{3},
+			}
+
+			Expect(expr).To(EvaluateAs(3, FakeBinding{}))
+		})
+
+		It("returns first if true", func() {
+			expr := CondExpr{
+				C: BooleanExpr{true},
+				T: IntegerExpr{2},
+				F: IntegerExpr{3},
+			}
+
+			Expect(expr).To(EvaluateAs(2, FakeBinding{}))
+		})
+	})
+
+	Context("on integer condition", func() {
+		It("returns first if not 0", func() {
+			expr := CondExpr{
+				C: IntegerExpr{1},
+				T: IntegerExpr{2},
+				F: IntegerExpr{3},
+			}
+
+			Expect(expr).To(EvaluateAs(2, FakeBinding{}))
+		})
+
+		It("returns second if 0", func() {
+			expr := CondExpr{
+				C: IntegerExpr{0},
+				T: IntegerExpr{2},
+				F: IntegerExpr{3},
+			}
+
+			Expect(expr).To(EvaluateAs(3, FakeBinding{}))
+		})
+	})
+
+	Context("on list condition", func() {
+		It("returns first if length != 0", func() {
+			expr := CondExpr{
+				C: ListExpr{[]Expression{IntegerExpr{1}}},
+				T: IntegerExpr{2},
+				F: IntegerExpr{3},
+			}
+
+			Expect(expr).To(EvaluateAs(2, FakeBinding{}))
+		})
+
+		It("returns second if length == 0", func() {
+			expr := CondExpr{
+				C: ListExpr{[]Expression{}},
+				T: IntegerExpr{2},
+				F: IntegerExpr{3},
+			}
+
+			Expect(expr).To(EvaluateAs(3, FakeBinding{}))
+		})
+	})
+
+	Context("on string condition", func() {
+		It("returns first if length != 0", func() {
+			expr := CondExpr{
+				C: StringExpr{"alice"},
+				T: IntegerExpr{2},
+				F: IntegerExpr{3},
+			}
+
+			Expect(expr).To(EvaluateAs(2, FakeBinding{}))
+		})
+
+		It("returns second if length == 0", func() {
+			expr := CondExpr{
+				C: StringExpr{""},
+				T: IntegerExpr{2},
+				F: IntegerExpr{3},
+			}
+
+			Expect(expr).To(EvaluateAs(3, FakeBinding{}))
+		})
+	})
+
+	Context("on map condition", func() {
+		It("returns first if length != 0", func() {
+			mapNode := node(map[string]yaml.Node{
+				"bar": node("alice"),
+			})
+			expr := CondExpr{
+				C: ReferenceExpr{[]string{"foo"}},
+				T: IntegerExpr{2},
+				F: IntegerExpr{3},
+			}
+
+			Expect(expr).To(EvaluateAs(2, FakeBinding{FoundReferences: map[string]yaml.Node{"foo": mapNode}}))
+		})
+
+		It("returns second if length == 0", func() {
+			mapNode := node(map[string]yaml.Node{})
+			expr := CondExpr{
+				C: ReferenceExpr{[]string{"foo"}},
+				T: IntegerExpr{2},
+				F: IntegerExpr{3},
+			}
+
+			Expect(expr).To(EvaluateAs(3, FakeBinding{FoundReferences: map[string]yaml.Node{"foo": mapNode}}))
+		})
+	})
+
+	Context("on failing condition", func() {
+		It("fails", func() {
+			expr := CondExpr{
+				C: FailingExpr{},
+				T: IntegerExpr{2},
+				F: IntegerExpr{3},
+			}
+
+			Expect(expr).To(FailToEvaluate(FakeBinding{}))
+		})
+	})
+})

--- a/dynaml/defined.go
+++ b/dynaml/defined.go
@@ -1,0 +1,23 @@
+package dynaml
+
+import (
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+func (e CallExpr) defined(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	pushed := make([]Expression, len(e.Arguments))
+	ok := true
+	resolved := true
+
+	copy(pushed, e.Arguments)
+	for i, _ := range pushed {
+		_, _, ok = ResolveExpressionOrPushEvaluation(&pushed[i], &resolved, nil, binding)
+		if resolved && !ok {
+			return node(false), DefaultInfo(), true
+		}
+	}
+	if !resolved {
+		return node(e), DefaultInfo(), true
+	}
+	return node(true), DefaultInfo(), ok
+}

--- a/dynaml/defined.go
+++ b/dynaml/defined.go
@@ -1,10 +1,6 @@
 package dynaml
 
-import (
-	"github.com/cloudfoundry-incubator/spiff/yaml"
-)
-
-func (e CallExpr) defined(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e CallExpr) defined(binding Binding) (interface{}, EvaluationInfo, bool) {
 	pushed := make([]Expression, len(e.Arguments))
 	ok := true
 	resolved := true
@@ -13,11 +9,11 @@ func (e CallExpr) defined(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 	for i, _ := range pushed {
 		_, _, ok = ResolveExpressionOrPushEvaluation(&pushed[i], &resolved, nil, binding)
 		if resolved && !ok {
-			return node(false), DefaultInfo(), true
+			return false, DefaultInfo(), true
 		}
 	}
 	if !resolved {
-		return node(e), DefaultInfo(), true
+		return e, DefaultInfo(), true
 	}
-	return node(true), DefaultInfo(), ok
+	return true, DefaultInfo(), ok
 }

--- a/dynaml/division.go
+++ b/dynaml/division.go
@@ -11,7 +11,7 @@ type DivisionExpr struct {
 	B Expression
 }
 
-func (e DivisionExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e DivisionExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 	resolved := true
 
 	aint, info, ok := ResolveIntegerExpressionOrPushEvaluation(&e.A, &resolved, nil, binding)
@@ -25,14 +25,14 @@ func (e DivisionExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool
 	}
 
 	if !resolved {
-		return node(e), info, true
+		return e, info, true
 	}
 
 	if bint == 0 {
 		info.Issue = yaml.NewIssue("division by zero")
 		return nil, info, false
 	}
-	return node(aint / bint), info, true
+	return aint / bint, info, true
 }
 
 func (e DivisionExpr) String() string {

--- a/dynaml/division.go
+++ b/dynaml/division.go
@@ -29,7 +29,7 @@ func (e DivisionExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool
 	}
 
 	if bint == 0 {
-		info.Issue = "division by zero"
+		info.Issue = yaml.NewIssue("division by zero")
 		return nil, info, false
 	}
 	return node(aint / bint), info, true

--- a/dynaml/dynaml.peg
+++ b/dynaml/dynaml.peg
@@ -32,25 +32,22 @@ Multiplication <- '*' req_ws Level0
 Division <-  '/' req_ws Level0
 Modulo <-  '%' req_ws Level0
 
-Level0 <- QualifiedExpression / Not / Call / Grouped / Boolean / Nil / 
-          String / Integer / List / Range / Merge / Auto / Mapping / Lambda / Reference
+Level0 <- String / Integer / Boolean / Nil / Not /
+          Merge / Auto / Lambda / Chained 
 
-QualifiedExpression <- ( Call / Grouped / List / Range ) '.' FollowUpRef
+Chained <- (( Mapping / List / Range / ( Grouped / Reference ) ChainedCall* ) ) ( ChainedQualifiedExpression ChainedCall+)* ChainedQualifiedExpression?
+ChainedQualifiedExpression <- '.' FollowUpRef 
+ChainedCall <- '(' Arguments ')'
+Arguments <- Expression (NextExpression)*
+NextExpression <- ',' Expression
+
 Not <- '!' ws Level0
 Grouped <- '(' Expression ')'
 Range <- '[' Expression '..' Expression ']'
 
-Call <- ( Reference / Grouped ) '(' Arguments ')'
-Name <- [a-zA-Z0-9_]+
-Arguments <- Expression (NextExpression)*
-NextExpression <- ',' Expression
-
-Integer <- '-'? [0-9_]+
-
+Integer <- '-'? [0-9] [0-9_]*
 String <- '"' ('\\"' / !'"' .)* '"'
-
 Boolean <- 'true' / 'false'
-
 Nil <- 'nil' / '~'
 
 List <- '[' Contents? ']'
@@ -70,6 +67,7 @@ Lambda <- 'lambda' ( LambdaRef / LambdaExpr )
 LambdaRef <- req_ws Expression
 LambdaExpr <- ws '|' ws Name (NextName)* ws '|' ws '->' Expression
 NextName <- ws ',' ws Name
+Name <- [a-zA-Z0-9_]+
 
 Reference <- '.'? Key ( '.' ( Key / Index) )*
 FollowUpRef <- ( Key / Index) ( '.' ( Key / Index) )*

--- a/dynaml/dynaml.peg
+++ b/dynaml/dynaml.peg
@@ -21,11 +21,11 @@ Multiplication <- '*' req_ws Level0
 Division <-  '/' req_ws Level0
 Modulo <-  '%' req_ws Level0
 
-Level0 <- Grouped / Call / Boolean / Nil / String / Integer / List / Merge / Auto / Mapping / Reference
+Level0 <- Call / Grouped / Boolean / Nil / String / Integer / List / Merge / Auto / Mapping / Lambda / Reference
 
 Grouped <- '(' Expression ')'
 
-Call <- Name '(' Arguments ')'
+Call <- ( Reference / Grouped ) '(' Arguments ')'
 Name <- [a-zA-Z0-9_]+
 Arguments <- Expression (NextExpression)*
 NextExpression <- ',' Expression
@@ -50,7 +50,11 @@ On <- 'on' req_ws Name
 
 Auto <- 'auto'
 
-Mapping <- 'map[' Expression '|' ws Name ( ws ',' ws Name)? ws '|' ws '->' Expression ']'
+Mapping <- 'map[' Expression '|' ws Name (NextName)? ws '|' ws '->' Expression ']'
+Lambda <- 'lambda' ( LambdaRef / LambdaExpr )
+LambdaRef <- req_ws Expression
+LambdaExpr <- ws '|' ws Name (NextName)* ws '|' ws '->' Expression
+NextName <- ws ',' ws Name
 
 Reference <- '.'? Key ('.' Key / '.' '[' [0-9]+ ']')*
 Key <- [a-zA-Z0-9_] [a-zA-Z0-9_\-]* ( ':' [a-zA-Z0-9_] [a-zA-Z0-9_\-]* )?

--- a/dynaml/dynaml.peg
+++ b/dynaml/dynaml.peg
@@ -4,13 +4,24 @@ type DynamlGrammar Peg {}
 
 Dynaml <- (Prefer / Expression) !.
 Prefer <- ws 'prefer' req_ws Expression
-Expression <- ws Level4 ws
+Expression <- ws Level7 ws
 
-Level4 <- Level3 ( req_ws Or )*
-Or <- '||' req_ws Level3
+Level7 <- Level6 ( req_ws Or )*
+Or <- '||' req_ws Level6
 
-Level3 <- Level2 ( Concatenation )*
-Concatenation <- req_ws Level2
+Level6 <- Conditional / Level5
+Conditional <- Level5 ws '?' Expression ':' Expression
+
+Level5 <- Level4 ( Concatenation )*
+Concatenation <- req_ws Level4
+
+Level4 <- Level3 ( req_ws ( LogOr / LogAnd ) )*
+LogOr <- '-or' req_ws Level3
+LogAnd <- '-and' req_ws Level3
+
+Level3 <- Level2 ( req_ws Comparison )*
+Comparison <- CompareOp req_ws Level2
+CompareOp <- '==' / '!=' / '<=' / '>=' / '>' / '<' / '>'
 
 Level2 <-  Level1 ( req_ws ( Addition / Subtraction ) )*
 Addition <- '+' req_ws Level1
@@ -21,9 +32,13 @@ Multiplication <- '*' req_ws Level0
 Division <-  '/' req_ws Level0
 Modulo <-  '%' req_ws Level0
 
-Level0 <- Call / Grouped / Boolean / Nil / String / Integer / List / Merge / Auto / Mapping / Lambda / Reference
+Level0 <- QualifiedExpression / Not / Call / Grouped / Boolean / Nil / 
+          String / Integer / List / Range / Merge / Auto / Mapping / Lambda / Reference
 
+QualifiedExpression <- ( Call / Grouped / List / Range ) '.' FollowUpRef
+Not <- '!' ws Level0
 Grouped <- '(' Expression ')'
+Range <- '[' Expression '..' Expression ']'
 
 Call <- ( Reference / Grouped ) '(' Arguments ')'
 Name <- [a-zA-Z0-9_]+
@@ -56,8 +71,11 @@ LambdaRef <- req_ws Expression
 LambdaExpr <- ws '|' ws Name (NextName)* ws '|' ws '->' Expression
 NextName <- ws ',' ws Name
 
-Reference <- '.'? Key ('.' Key / '.' '[' [0-9]+ ']')*
+Reference <- '.'? Key ( '.' ( Key / Index) )*
+FollowUpRef <- ( Key / Index) ( '.' ( Key / Index) )*
+
 Key <- [a-zA-Z0-9_] [a-zA-Z0-9_\-]* ( ':' [a-zA-Z0-9_] [a-zA-Z0-9_\-]* )?
+Index <- '[' [0-9]+ ']'
 
 ws <- [ \t\n\r]*
 

--- a/dynaml/dynaml.peg
+++ b/dynaml/dynaml.peg
@@ -50,7 +50,7 @@ On <- 'on' req_ws Name
 
 Auto <- 'auto'
 
-Mapping <- 'map[' Expression '|' ws Name (NextName)? ws '|' ws '->' Expression ']'
+Mapping <- 'map[' Expression ( LambdaExpr / ( '|' Expression )) ']'
 Lambda <- 'lambda' ( LambdaRef / LambdaExpr )
 LambdaRef <- req_ws Expression
 LambdaExpr <- ws '|' ws Name (NextName)* ws '|' ws '->' Expression

--- a/dynaml/dynaml.peg
+++ b/dynaml/dynaml.peg
@@ -2,8 +2,9 @@ package dynaml
 
 type DynamlGrammar Peg {}
 
-Dynaml <- (Prefer / Expression) !.
+Dynaml <- (Prefer / Template / Expression) !.
 Prefer <- ws 'prefer' req_ws Expression
+Template <- ws '&template' ws
 Expression <- ws ( LambdaExpr / Level7 ) ws
 
 Level7 <- Level6 ( req_ws Or )*
@@ -33,7 +34,7 @@ Division <-  '/' req_ws Level0
 Modulo <-  '%' req_ws Level0
 
 Level0 <- String / Integer / Boolean / Nil / Not /
-          Merge / Auto / Lambda / Chained 
+          Substitution / Merge / Auto / Lambda / Chained 
 
 Chained <- (( Mapping / List / Range / ( Grouped / Reference ) ChainedCall* ) ) ( ChainedQualifiedExpression ChainedCall+)* ChainedQualifiedExpression?
 ChainedQualifiedExpression <- '.' FollowUpRef 
@@ -41,6 +42,7 @@ ChainedCall <- '(' Arguments ')'
 Arguments <- Expression (NextExpression)*
 NextExpression <- ',' Expression
 
+Substitution <- '*' Level0
 Not <- '!' ws Level0
 Grouped <- '(' Expression ')'
 Range <- '[' Expression '..' Expression ']'

--- a/dynaml/dynaml.peg
+++ b/dynaml/dynaml.peg
@@ -4,7 +4,7 @@ type DynamlGrammar Peg {}
 
 Dynaml <- (Prefer / Expression) !.
 Prefer <- ws 'prefer' req_ws Expression
-Expression <- ws Level7 ws
+Expression <- ws ( LambdaExpr / Level7 ) ws
 
 Level7 <- Level6 ( req_ws Or )*
 Or <- '||' req_ws Level6
@@ -65,7 +65,7 @@ On <- 'on' req_ws Name
 
 Auto <- 'auto'
 
-Mapping <- 'map[' Expression ( LambdaExpr / ( '|' Expression )) ']'
+Mapping <- 'map[' Level7 ( LambdaExpr / ( '|' Expression )) ']'
 Lambda <- 'lambda' ( LambdaRef / LambdaExpr )
 LambdaRef <- req_ws Expression
 LambdaExpr <- ws '|' ws Name (NextName)* ws '|' ws '->' Expression

--- a/dynaml/dynaml.peg.go
+++ b/dynaml/dynaml.peg.go
@@ -48,6 +48,10 @@ const (
 	ruleOn
 	ruleAuto
 	ruleMapping
+	ruleLambda
+	ruleLambdaRef
+	ruleLambdaExpr
+	ruleNextName
 	ruleReference
 	ruleKey
 	rulews
@@ -94,6 +98,10 @@ var rul3s = [...]string{
 	"On",
 	"Auto",
 	"Mapping",
+	"Lambda",
+	"LambdaRef",
+	"LambdaExpr",
+	"NextName",
 	"Reference",
 	"Key",
 	"ws",
@@ -416,7 +424,7 @@ func (t *tokens32) Expand(index int) tokenTree {
 type DynamlGrammar struct {
 	Buffer string
 	buffer []rune
-	rules  [39]func() bool
+	rules  [43]func() bool
 	Parse  func(rule ...int) error
 	Reset  func()
 	tokenTree
@@ -963,7 +971,7 @@ func (p *DynamlGrammar) Init() {
 			position, tokenIndex, depth = position42, tokenIndex42, depth42
 			return false
 		},
-		/* 14 Level0 <- <(Grouped / Call / Boolean / Nil / String / Integer / List / Merge / Auto / Mapping / Reference)> */
+		/* 14 Level0 <- <(Call / Grouped / Boolean / Nil / String / Integer / List / Merge / Auto / Mapping / Lambda / Reference)> */
 		func() bool {
 			position44, tokenIndex44, depth44 := position, tokenIndex, depth
 			{
@@ -971,13 +979,13 @@ func (p *DynamlGrammar) Init() {
 				depth++
 				{
 					position46, tokenIndex46, depth46 := position, tokenIndex, depth
-					if !_rules[ruleGrouped]() {
+					if !_rules[ruleCall]() {
 						goto l47
 					}
 					goto l46
 				l47:
 					position, tokenIndex, depth = position46, tokenIndex46, depth46
-					if !_rules[ruleCall]() {
+					if !_rules[ruleGrouped]() {
 						goto l48
 					}
 					goto l46
@@ -1031,6 +1039,12 @@ func (p *DynamlGrammar) Init() {
 					goto l46
 				l56:
 					position, tokenIndex, depth = position46, tokenIndex46, depth46
+					if !_rules[ruleLambda]() {
+						goto l57
+					}
+					goto l46
+				l57:
+					position, tokenIndex, depth = position46, tokenIndex46, depth46
 					if !_rules[ruleReference]() {
 						goto l44
 					}
@@ -1046,1223 +1060,1379 @@ func (p *DynamlGrammar) Init() {
 		},
 		/* 15 Grouped <- <('(' Expression ')')> */
 		func() bool {
-			position57, tokenIndex57, depth57 := position, tokenIndex, depth
+			position58, tokenIndex58, depth58 := position, tokenIndex, depth
 			{
-				position58 := position
+				position59 := position
 				depth++
 				if buffer[position] != rune('(') {
-					goto l57
+					goto l58
 				}
 				position++
 				if !_rules[ruleExpression]() {
-					goto l57
+					goto l58
 				}
 				if buffer[position] != rune(')') {
-					goto l57
+					goto l58
 				}
 				position++
 				depth--
-				add(ruleGrouped, position58)
+				add(ruleGrouped, position59)
 			}
 			return true
-		l57:
-			position, tokenIndex, depth = position57, tokenIndex57, depth57
+		l58:
+			position, tokenIndex, depth = position58, tokenIndex58, depth58
 			return false
 		},
-		/* 16 Call <- <(Name '(' Arguments ')')> */
+		/* 16 Call <- <((Reference / Grouped) '(' Arguments ')')> */
 		func() bool {
-			position59, tokenIndex59, depth59 := position, tokenIndex, depth
+			position60, tokenIndex60, depth60 := position, tokenIndex, depth
 			{
-				position60 := position
+				position61 := position
 				depth++
-				if !_rules[ruleName]() {
-					goto l59
+				{
+					position62, tokenIndex62, depth62 := position, tokenIndex, depth
+					if !_rules[ruleReference]() {
+						goto l63
+					}
+					goto l62
+				l63:
+					position, tokenIndex, depth = position62, tokenIndex62, depth62
+					if !_rules[ruleGrouped]() {
+						goto l60
+					}
 				}
+			l62:
 				if buffer[position] != rune('(') {
-					goto l59
+					goto l60
 				}
 				position++
 				if !_rules[ruleArguments]() {
-					goto l59
+					goto l60
 				}
 				if buffer[position] != rune(')') {
-					goto l59
+					goto l60
 				}
 				position++
 				depth--
-				add(ruleCall, position60)
+				add(ruleCall, position61)
 			}
 			return true
-		l59:
-			position, tokenIndex, depth = position59, tokenIndex59, depth59
+		l60:
+			position, tokenIndex, depth = position60, tokenIndex60, depth60
 			return false
 		},
 		/* 17 Name <- <([a-z] / [A-Z] / [0-9] / '_')+> */
 		func() bool {
-			position61, tokenIndex61, depth61 := position, tokenIndex, depth
+			position64, tokenIndex64, depth64 := position, tokenIndex, depth
 			{
-				position62 := position
+				position65 := position
 				depth++
 				{
-					position65, tokenIndex65, depth65 := position, tokenIndex, depth
+					position68, tokenIndex68, depth68 := position, tokenIndex, depth
 					if c := buffer[position]; c < rune('a') || c > rune('z') {
-						goto l66
+						goto l69
 					}
 					position++
-					goto l65
-				l66:
-					position, tokenIndex, depth = position65, tokenIndex65, depth65
+					goto l68
+				l69:
+					position, tokenIndex, depth = position68, tokenIndex68, depth68
 					if c := buffer[position]; c < rune('A') || c > rune('Z') {
-						goto l67
+						goto l70
 					}
 					position++
-					goto l65
-				l67:
-					position, tokenIndex, depth = position65, tokenIndex65, depth65
+					goto l68
+				l70:
+					position, tokenIndex, depth = position68, tokenIndex68, depth68
 					if c := buffer[position]; c < rune('0') || c > rune('9') {
-						goto l68
+						goto l71
 					}
 					position++
-					goto l65
-				l68:
-					position, tokenIndex, depth = position65, tokenIndex65, depth65
+					goto l68
+				l71:
+					position, tokenIndex, depth = position68, tokenIndex68, depth68
 					if buffer[position] != rune('_') {
-						goto l61
+						goto l64
 					}
 					position++
 				}
-			l65:
-			l63:
+			l68:
+			l66:
 				{
-					position64, tokenIndex64, depth64 := position, tokenIndex, depth
+					position67, tokenIndex67, depth67 := position, tokenIndex, depth
 					{
-						position69, tokenIndex69, depth69 := position, tokenIndex, depth
+						position72, tokenIndex72, depth72 := position, tokenIndex, depth
 						if c := buffer[position]; c < rune('a') || c > rune('z') {
-							goto l70
+							goto l73
 						}
 						position++
-						goto l69
-					l70:
-						position, tokenIndex, depth = position69, tokenIndex69, depth69
+						goto l72
+					l73:
+						position, tokenIndex, depth = position72, tokenIndex72, depth72
 						if c := buffer[position]; c < rune('A') || c > rune('Z') {
-							goto l71
+							goto l74
 						}
 						position++
-						goto l69
-					l71:
-						position, tokenIndex, depth = position69, tokenIndex69, depth69
+						goto l72
+					l74:
+						position, tokenIndex, depth = position72, tokenIndex72, depth72
 						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l72
+							goto l75
 						}
 						position++
-						goto l69
-					l72:
-						position, tokenIndex, depth = position69, tokenIndex69, depth69
+						goto l72
+					l75:
+						position, tokenIndex, depth = position72, tokenIndex72, depth72
 						if buffer[position] != rune('_') {
-							goto l64
+							goto l67
 						}
 						position++
 					}
-				l69:
-					goto l63
-				l64:
-					position, tokenIndex, depth = position64, tokenIndex64, depth64
+				l72:
+					goto l66
+				l67:
+					position, tokenIndex, depth = position67, tokenIndex67, depth67
 				}
 				depth--
-				add(ruleName, position62)
+				add(ruleName, position65)
 			}
 			return true
-		l61:
-			position, tokenIndex, depth = position61, tokenIndex61, depth61
+		l64:
+			position, tokenIndex, depth = position64, tokenIndex64, depth64
 			return false
 		},
 		/* 18 Arguments <- <(Expression NextExpression*)> */
 		func() bool {
-			position73, tokenIndex73, depth73 := position, tokenIndex, depth
+			position76, tokenIndex76, depth76 := position, tokenIndex, depth
 			{
-				position74 := position
+				position77 := position
 				depth++
 				if !_rules[ruleExpression]() {
-					goto l73
+					goto l76
 				}
-			l75:
+			l78:
 				{
-					position76, tokenIndex76, depth76 := position, tokenIndex, depth
+					position79, tokenIndex79, depth79 := position, tokenIndex, depth
 					if !_rules[ruleNextExpression]() {
-						goto l76
+						goto l79
 					}
-					goto l75
-				l76:
-					position, tokenIndex, depth = position76, tokenIndex76, depth76
+					goto l78
+				l79:
+					position, tokenIndex, depth = position79, tokenIndex79, depth79
 				}
 				depth--
-				add(ruleArguments, position74)
+				add(ruleArguments, position77)
 			}
 			return true
-		l73:
-			position, tokenIndex, depth = position73, tokenIndex73, depth73
+		l76:
+			position, tokenIndex, depth = position76, tokenIndex76, depth76
 			return false
 		},
 		/* 19 NextExpression <- <(',' Expression)> */
 		func() bool {
-			position77, tokenIndex77, depth77 := position, tokenIndex, depth
+			position80, tokenIndex80, depth80 := position, tokenIndex, depth
 			{
-				position78 := position
+				position81 := position
 				depth++
 				if buffer[position] != rune(',') {
-					goto l77
+					goto l80
 				}
 				position++
 				if !_rules[ruleExpression]() {
-					goto l77
+					goto l80
 				}
 				depth--
-				add(ruleNextExpression, position78)
+				add(ruleNextExpression, position81)
 			}
 			return true
-		l77:
-			position, tokenIndex, depth = position77, tokenIndex77, depth77
+		l80:
+			position, tokenIndex, depth = position80, tokenIndex80, depth80
 			return false
 		},
 		/* 20 Integer <- <('-'? ([0-9] / '_')+)> */
 		func() bool {
-			position79, tokenIndex79, depth79 := position, tokenIndex, depth
+			position82, tokenIndex82, depth82 := position, tokenIndex, depth
 			{
-				position80 := position
+				position83 := position
 				depth++
 				{
-					position81, tokenIndex81, depth81 := position, tokenIndex, depth
+					position84, tokenIndex84, depth84 := position, tokenIndex, depth
 					if buffer[position] != rune('-') {
-						goto l81
-					}
-					position++
-					goto l82
-				l81:
-					position, tokenIndex, depth = position81, tokenIndex81, depth81
-				}
-			l82:
-				{
-					position85, tokenIndex85, depth85 := position, tokenIndex, depth
-					if c := buffer[position]; c < rune('0') || c > rune('9') {
-						goto l86
+						goto l84
 					}
 					position++
 					goto l85
-				l86:
-					position, tokenIndex, depth = position85, tokenIndex85, depth85
-					if buffer[position] != rune('_') {
-						goto l79
-					}
-					position++
-				}
-			l85:
-			l83:
-				{
-					position84, tokenIndex84, depth84 := position, tokenIndex, depth
-					{
-						position87, tokenIndex87, depth87 := position, tokenIndex, depth
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l88
-						}
-						position++
-						goto l87
-					l88:
-						position, tokenIndex, depth = position87, tokenIndex87, depth87
-						if buffer[position] != rune('_') {
-							goto l84
-						}
-						position++
-					}
-				l87:
-					goto l83
 				l84:
 					position, tokenIndex, depth = position84, tokenIndex84, depth84
 				}
+			l85:
+				{
+					position88, tokenIndex88, depth88 := position, tokenIndex, depth
+					if c := buffer[position]; c < rune('0') || c > rune('9') {
+						goto l89
+					}
+					position++
+					goto l88
+				l89:
+					position, tokenIndex, depth = position88, tokenIndex88, depth88
+					if buffer[position] != rune('_') {
+						goto l82
+					}
+					position++
+				}
+			l88:
+			l86:
+				{
+					position87, tokenIndex87, depth87 := position, tokenIndex, depth
+					{
+						position90, tokenIndex90, depth90 := position, tokenIndex, depth
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l91
+						}
+						position++
+						goto l90
+					l91:
+						position, tokenIndex, depth = position90, tokenIndex90, depth90
+						if buffer[position] != rune('_') {
+							goto l87
+						}
+						position++
+					}
+				l90:
+					goto l86
+				l87:
+					position, tokenIndex, depth = position87, tokenIndex87, depth87
+				}
 				depth--
-				add(ruleInteger, position80)
+				add(ruleInteger, position83)
 			}
 			return true
-		l79:
-			position, tokenIndex, depth = position79, tokenIndex79, depth79
+		l82:
+			position, tokenIndex, depth = position82, tokenIndex82, depth82
 			return false
 		},
 		/* 21 String <- <('"' (('\\' '"') / (!'"' .))* '"')> */
 		func() bool {
-			position89, tokenIndex89, depth89 := position, tokenIndex, depth
+			position92, tokenIndex92, depth92 := position, tokenIndex, depth
 			{
-				position90 := position
+				position93 := position
 				depth++
 				if buffer[position] != rune('"') {
-					goto l89
+					goto l92
 				}
 				position++
-			l91:
+			l94:
 				{
-					position92, tokenIndex92, depth92 := position, tokenIndex, depth
+					position95, tokenIndex95, depth95 := position, tokenIndex, depth
 					{
-						position93, tokenIndex93, depth93 := position, tokenIndex, depth
+						position96, tokenIndex96, depth96 := position, tokenIndex, depth
 						if buffer[position] != rune('\\') {
-							goto l94
+							goto l97
 						}
 						position++
 						if buffer[position] != rune('"') {
-							goto l94
+							goto l97
 						}
 						position++
-						goto l93
-					l94:
-						position, tokenIndex, depth = position93, tokenIndex93, depth93
+						goto l96
+					l97:
+						position, tokenIndex, depth = position96, tokenIndex96, depth96
 						{
-							position95, tokenIndex95, depth95 := position, tokenIndex, depth
+							position98, tokenIndex98, depth98 := position, tokenIndex, depth
 							if buffer[position] != rune('"') {
-								goto l95
+								goto l98
 							}
 							position++
-							goto l92
-						l95:
-							position, tokenIndex, depth = position95, tokenIndex95, depth95
+							goto l95
+						l98:
+							position, tokenIndex, depth = position98, tokenIndex98, depth98
 						}
 						if !matchDot() {
-							goto l92
+							goto l95
 						}
 					}
-				l93:
-					goto l91
-				l92:
-					position, tokenIndex, depth = position92, tokenIndex92, depth92
+				l96:
+					goto l94
+				l95:
+					position, tokenIndex, depth = position95, tokenIndex95, depth95
 				}
 				if buffer[position] != rune('"') {
-					goto l89
+					goto l92
 				}
 				position++
 				depth--
-				add(ruleString, position90)
+				add(ruleString, position93)
 			}
 			return true
-		l89:
-			position, tokenIndex, depth = position89, tokenIndex89, depth89
+		l92:
+			position, tokenIndex, depth = position92, tokenIndex92, depth92
 			return false
 		},
 		/* 22 Boolean <- <(('t' 'r' 'u' 'e') / ('f' 'a' 'l' 's' 'e'))> */
 		func() bool {
-			position96, tokenIndex96, depth96 := position, tokenIndex, depth
+			position99, tokenIndex99, depth99 := position, tokenIndex, depth
 			{
-				position97 := position
+				position100 := position
 				depth++
 				{
-					position98, tokenIndex98, depth98 := position, tokenIndex, depth
+					position101, tokenIndex101, depth101 := position, tokenIndex, depth
 					if buffer[position] != rune('t') {
-						goto l99
+						goto l102
 					}
 					position++
 					if buffer[position] != rune('r') {
-						goto l99
+						goto l102
 					}
 					position++
 					if buffer[position] != rune('u') {
-						goto l99
+						goto l102
 					}
 					position++
 					if buffer[position] != rune('e') {
-						goto l99
+						goto l102
 					}
 					position++
-					goto l98
-				l99:
-					position, tokenIndex, depth = position98, tokenIndex98, depth98
+					goto l101
+				l102:
+					position, tokenIndex, depth = position101, tokenIndex101, depth101
 					if buffer[position] != rune('f') {
-						goto l96
+						goto l99
 					}
 					position++
 					if buffer[position] != rune('a') {
-						goto l96
+						goto l99
 					}
 					position++
 					if buffer[position] != rune('l') {
-						goto l96
+						goto l99
 					}
 					position++
 					if buffer[position] != rune('s') {
-						goto l96
+						goto l99
 					}
 					position++
 					if buffer[position] != rune('e') {
-						goto l96
+						goto l99
 					}
 					position++
 				}
-			l98:
+			l101:
 				depth--
-				add(ruleBoolean, position97)
+				add(ruleBoolean, position100)
 			}
 			return true
-		l96:
-			position, tokenIndex, depth = position96, tokenIndex96, depth96
+		l99:
+			position, tokenIndex, depth = position99, tokenIndex99, depth99
 			return false
 		},
 		/* 23 Nil <- <(('n' 'i' 'l') / '~')> */
 		func() bool {
-			position100, tokenIndex100, depth100 := position, tokenIndex, depth
+			position103, tokenIndex103, depth103 := position, tokenIndex, depth
 			{
-				position101 := position
+				position104 := position
 				depth++
 				{
-					position102, tokenIndex102, depth102 := position, tokenIndex, depth
+					position105, tokenIndex105, depth105 := position, tokenIndex, depth
 					if buffer[position] != rune('n') {
-						goto l103
+						goto l106
 					}
 					position++
 					if buffer[position] != rune('i') {
-						goto l103
+						goto l106
 					}
 					position++
 					if buffer[position] != rune('l') {
+						goto l106
+					}
+					position++
+					goto l105
+				l106:
+					position, tokenIndex, depth = position105, tokenIndex105, depth105
+					if buffer[position] != rune('~') {
 						goto l103
 					}
 					position++
-					goto l102
-				l103:
-					position, tokenIndex, depth = position102, tokenIndex102, depth102
-					if buffer[position] != rune('~') {
-						goto l100
-					}
-					position++
 				}
-			l102:
+			l105:
 				depth--
-				add(ruleNil, position101)
+				add(ruleNil, position104)
 			}
 			return true
-		l100:
-			position, tokenIndex, depth = position100, tokenIndex100, depth100
+		l103:
+			position, tokenIndex, depth = position103, tokenIndex103, depth103
 			return false
 		},
 		/* 24 List <- <('[' Contents? ']')> */
 		func() bool {
-			position104, tokenIndex104, depth104 := position, tokenIndex, depth
+			position107, tokenIndex107, depth107 := position, tokenIndex, depth
 			{
-				position105 := position
+				position108 := position
 				depth++
 				if buffer[position] != rune('[') {
-					goto l104
+					goto l107
 				}
 				position++
 				{
-					position106, tokenIndex106, depth106 := position, tokenIndex, depth
+					position109, tokenIndex109, depth109 := position, tokenIndex, depth
 					if !_rules[ruleContents]() {
-						goto l106
+						goto l109
 					}
-					goto l107
-				l106:
-					position, tokenIndex, depth = position106, tokenIndex106, depth106
+					goto l110
+				l109:
+					position, tokenIndex, depth = position109, tokenIndex109, depth109
 				}
-			l107:
+			l110:
 				if buffer[position] != rune(']') {
-					goto l104
+					goto l107
 				}
 				position++
 				depth--
-				add(ruleList, position105)
+				add(ruleList, position108)
 			}
 			return true
-		l104:
-			position, tokenIndex, depth = position104, tokenIndex104, depth104
+		l107:
+			position, tokenIndex, depth = position107, tokenIndex107, depth107
 			return false
 		},
 		/* 25 Contents <- <(Expression NextExpression*)> */
 		func() bool {
-			position108, tokenIndex108, depth108 := position, tokenIndex, depth
+			position111, tokenIndex111, depth111 := position, tokenIndex, depth
 			{
-				position109 := position
+				position112 := position
 				depth++
 				if !_rules[ruleExpression]() {
-					goto l108
+					goto l111
 				}
-			l110:
+			l113:
 				{
-					position111, tokenIndex111, depth111 := position, tokenIndex, depth
+					position114, tokenIndex114, depth114 := position, tokenIndex, depth
 					if !_rules[ruleNextExpression]() {
-						goto l111
+						goto l114
 					}
-					goto l110
-				l111:
-					position, tokenIndex, depth = position111, tokenIndex111, depth111
+					goto l113
+				l114:
+					position, tokenIndex, depth = position114, tokenIndex114, depth114
 				}
 				depth--
-				add(ruleContents, position109)
+				add(ruleContents, position112)
 			}
 			return true
-		l108:
-			position, tokenIndex, depth = position108, tokenIndex108, depth108
+		l111:
+			position, tokenIndex, depth = position111, tokenIndex111, depth111
 			return false
 		},
 		/* 26 Merge <- <(RefMerge / SimpleMerge)> */
 		func() bool {
-			position112, tokenIndex112, depth112 := position, tokenIndex, depth
+			position115, tokenIndex115, depth115 := position, tokenIndex, depth
 			{
-				position113 := position
+				position116 := position
 				depth++
 				{
-					position114, tokenIndex114, depth114 := position, tokenIndex, depth
+					position117, tokenIndex117, depth117 := position, tokenIndex, depth
 					if !_rules[ruleRefMerge]() {
+						goto l118
+					}
+					goto l117
+				l118:
+					position, tokenIndex, depth = position117, tokenIndex117, depth117
+					if !_rules[ruleSimpleMerge]() {
 						goto l115
 					}
-					goto l114
-				l115:
-					position, tokenIndex, depth = position114, tokenIndex114, depth114
-					if !_rules[ruleSimpleMerge]() {
-						goto l112
-					}
 				}
-			l114:
+			l117:
 				depth--
-				add(ruleMerge, position113)
+				add(ruleMerge, position116)
 			}
 			return true
-		l112:
-			position, tokenIndex, depth = position112, tokenIndex112, depth112
+		l115:
+			position, tokenIndex, depth = position115, tokenIndex115, depth115
 			return false
 		},
 		/* 27 RefMerge <- <('m' 'e' 'r' 'g' 'e' !(req_ws Required) (req_ws (Replace / On))? req_ws Reference)> */
 		func() bool {
-			position116, tokenIndex116, depth116 := position, tokenIndex, depth
+			position119, tokenIndex119, depth119 := position, tokenIndex, depth
 			{
-				position117 := position
+				position120 := position
 				depth++
 				if buffer[position] != rune('m') {
-					goto l116
+					goto l119
 				}
 				position++
 				if buffer[position] != rune('e') {
-					goto l116
+					goto l119
 				}
 				position++
 				if buffer[position] != rune('r') {
-					goto l116
+					goto l119
 				}
 				position++
 				if buffer[position] != rune('g') {
-					goto l116
+					goto l119
 				}
 				position++
 				if buffer[position] != rune('e') {
-					goto l116
+					goto l119
 				}
 				position++
 				{
-					position118, tokenIndex118, depth118 := position, tokenIndex, depth
+					position121, tokenIndex121, depth121 := position, tokenIndex, depth
 					if !_rules[rulereq_ws]() {
-						goto l118
+						goto l121
 					}
 					if !_rules[ruleRequired]() {
-						goto l118
+						goto l121
 					}
-					goto l116
-				l118:
-					position, tokenIndex, depth = position118, tokenIndex118, depth118
+					goto l119
+				l121:
+					position, tokenIndex, depth = position121, tokenIndex121, depth121
 				}
 				{
-					position119, tokenIndex119, depth119 := position, tokenIndex, depth
+					position122, tokenIndex122, depth122 := position, tokenIndex, depth
 					if !_rules[rulereq_ws]() {
-						goto l119
+						goto l122
 					}
 					{
-						position121, tokenIndex121, depth121 := position, tokenIndex, depth
+						position124, tokenIndex124, depth124 := position, tokenIndex, depth
 						if !_rules[ruleReplace]() {
+							goto l125
+						}
+						goto l124
+					l125:
+						position, tokenIndex, depth = position124, tokenIndex124, depth124
+						if !_rules[ruleOn]() {
 							goto l122
 						}
-						goto l121
-					l122:
-						position, tokenIndex, depth = position121, tokenIndex121, depth121
-						if !_rules[ruleOn]() {
-							goto l119
-						}
 					}
-				l121:
-					goto l120
-				l119:
-					position, tokenIndex, depth = position119, tokenIndex119, depth119
+				l124:
+					goto l123
+				l122:
+					position, tokenIndex, depth = position122, tokenIndex122, depth122
 				}
-			l120:
+			l123:
 				if !_rules[rulereq_ws]() {
-					goto l116
+					goto l119
 				}
 				if !_rules[ruleReference]() {
-					goto l116
+					goto l119
 				}
 				depth--
-				add(ruleRefMerge, position117)
+				add(ruleRefMerge, position120)
 			}
 			return true
-		l116:
-			position, tokenIndex, depth = position116, tokenIndex116, depth116
+		l119:
+			position, tokenIndex, depth = position119, tokenIndex119, depth119
 			return false
 		},
 		/* 28 SimpleMerge <- <('m' 'e' 'r' 'g' 'e' (req_ws (Replace / Required / On))?)> */
 		func() bool {
-			position123, tokenIndex123, depth123 := position, tokenIndex, depth
+			position126, tokenIndex126, depth126 := position, tokenIndex, depth
 			{
-				position124 := position
+				position127 := position
 				depth++
 				if buffer[position] != rune('m') {
-					goto l123
+					goto l126
 				}
 				position++
 				if buffer[position] != rune('e') {
-					goto l123
+					goto l126
 				}
 				position++
 				if buffer[position] != rune('r') {
-					goto l123
+					goto l126
 				}
 				position++
 				if buffer[position] != rune('g') {
-					goto l123
+					goto l126
 				}
 				position++
 				if buffer[position] != rune('e') {
-					goto l123
+					goto l126
 				}
 				position++
 				{
-					position125, tokenIndex125, depth125 := position, tokenIndex, depth
+					position128, tokenIndex128, depth128 := position, tokenIndex, depth
 					if !_rules[rulereq_ws]() {
-						goto l125
+						goto l128
 					}
 					{
-						position127, tokenIndex127, depth127 := position, tokenIndex, depth
+						position130, tokenIndex130, depth130 := position, tokenIndex, depth
 						if !_rules[ruleReplace]() {
+							goto l131
+						}
+						goto l130
+					l131:
+						position, tokenIndex, depth = position130, tokenIndex130, depth130
+						if !_rules[ruleRequired]() {
+							goto l132
+						}
+						goto l130
+					l132:
+						position, tokenIndex, depth = position130, tokenIndex130, depth130
+						if !_rules[ruleOn]() {
 							goto l128
 						}
-						goto l127
-					l128:
-						position, tokenIndex, depth = position127, tokenIndex127, depth127
-						if !_rules[ruleRequired]() {
-							goto l129
-						}
-						goto l127
-					l129:
-						position, tokenIndex, depth = position127, tokenIndex127, depth127
-						if !_rules[ruleOn]() {
-							goto l125
-						}
 					}
-				l127:
-					goto l126
-				l125:
-					position, tokenIndex, depth = position125, tokenIndex125, depth125
+				l130:
+					goto l129
+				l128:
+					position, tokenIndex, depth = position128, tokenIndex128, depth128
 				}
-			l126:
+			l129:
 				depth--
-				add(ruleSimpleMerge, position124)
+				add(ruleSimpleMerge, position127)
 			}
 			return true
-		l123:
-			position, tokenIndex, depth = position123, tokenIndex123, depth123
+		l126:
+			position, tokenIndex, depth = position126, tokenIndex126, depth126
 			return false
 		},
 		/* 29 Replace <- <('r' 'e' 'p' 'l' 'a' 'c' 'e')> */
 		func() bool {
-			position130, tokenIndex130, depth130 := position, tokenIndex, depth
+			position133, tokenIndex133, depth133 := position, tokenIndex, depth
 			{
-				position131 := position
+				position134 := position
 				depth++
 				if buffer[position] != rune('r') {
-					goto l130
+					goto l133
 				}
 				position++
 				if buffer[position] != rune('e') {
-					goto l130
+					goto l133
 				}
 				position++
 				if buffer[position] != rune('p') {
-					goto l130
+					goto l133
 				}
 				position++
 				if buffer[position] != rune('l') {
-					goto l130
+					goto l133
 				}
 				position++
 				if buffer[position] != rune('a') {
-					goto l130
+					goto l133
 				}
 				position++
 				if buffer[position] != rune('c') {
-					goto l130
+					goto l133
 				}
 				position++
 				if buffer[position] != rune('e') {
-					goto l130
+					goto l133
 				}
 				position++
 				depth--
-				add(ruleReplace, position131)
+				add(ruleReplace, position134)
 			}
 			return true
-		l130:
-			position, tokenIndex, depth = position130, tokenIndex130, depth130
+		l133:
+			position, tokenIndex, depth = position133, tokenIndex133, depth133
 			return false
 		},
 		/* 30 Required <- <('r' 'e' 'q' 'u' 'i' 'r' 'e' 'd')> */
 		func() bool {
-			position132, tokenIndex132, depth132 := position, tokenIndex, depth
+			position135, tokenIndex135, depth135 := position, tokenIndex, depth
 			{
-				position133 := position
+				position136 := position
 				depth++
 				if buffer[position] != rune('r') {
-					goto l132
+					goto l135
 				}
 				position++
 				if buffer[position] != rune('e') {
-					goto l132
+					goto l135
 				}
 				position++
 				if buffer[position] != rune('q') {
-					goto l132
+					goto l135
 				}
 				position++
 				if buffer[position] != rune('u') {
-					goto l132
+					goto l135
 				}
 				position++
 				if buffer[position] != rune('i') {
-					goto l132
+					goto l135
 				}
 				position++
 				if buffer[position] != rune('r') {
-					goto l132
+					goto l135
 				}
 				position++
 				if buffer[position] != rune('e') {
-					goto l132
+					goto l135
 				}
 				position++
 				if buffer[position] != rune('d') {
-					goto l132
+					goto l135
 				}
 				position++
 				depth--
-				add(ruleRequired, position133)
+				add(ruleRequired, position136)
 			}
 			return true
-		l132:
-			position, tokenIndex, depth = position132, tokenIndex132, depth132
+		l135:
+			position, tokenIndex, depth = position135, tokenIndex135, depth135
 			return false
 		},
 		/* 31 On <- <('o' 'n' req_ws Name)> */
 		func() bool {
-			position134, tokenIndex134, depth134 := position, tokenIndex, depth
+			position137, tokenIndex137, depth137 := position, tokenIndex, depth
 			{
-				position135 := position
+				position138 := position
 				depth++
 				if buffer[position] != rune('o') {
-					goto l134
+					goto l137
 				}
 				position++
 				if buffer[position] != rune('n') {
-					goto l134
+					goto l137
 				}
 				position++
 				if !_rules[rulereq_ws]() {
-					goto l134
+					goto l137
 				}
 				if !_rules[ruleName]() {
-					goto l134
+					goto l137
 				}
 				depth--
-				add(ruleOn, position135)
+				add(ruleOn, position138)
 			}
 			return true
-		l134:
-			position, tokenIndex, depth = position134, tokenIndex134, depth134
+		l137:
+			position, tokenIndex, depth = position137, tokenIndex137, depth137
 			return false
 		},
 		/* 32 Auto <- <('a' 'u' 't' 'o')> */
 		func() bool {
-			position136, tokenIndex136, depth136 := position, tokenIndex, depth
+			position139, tokenIndex139, depth139 := position, tokenIndex, depth
 			{
-				position137 := position
+				position140 := position
 				depth++
 				if buffer[position] != rune('a') {
-					goto l136
+					goto l139
 				}
 				position++
 				if buffer[position] != rune('u') {
-					goto l136
+					goto l139
 				}
 				position++
 				if buffer[position] != rune('t') {
-					goto l136
+					goto l139
 				}
 				position++
 				if buffer[position] != rune('o') {
-					goto l136
+					goto l139
 				}
 				position++
 				depth--
-				add(ruleAuto, position137)
+				add(ruleAuto, position140)
 			}
 			return true
-		l136:
-			position, tokenIndex, depth = position136, tokenIndex136, depth136
+		l139:
+			position, tokenIndex, depth = position139, tokenIndex139, depth139
 			return false
 		},
-		/* 33 Mapping <- <('m' 'a' 'p' '[' Expression '|' ws Name (ws ',' ws Name)? ws '|' ws ('-' '>') Expression ']')> */
+		/* 33 Mapping <- <('m' 'a' 'p' '[' Expression '|' ws Name NextName? ws '|' ws ('-' '>') Expression ']')> */
 		func() bool {
-			position138, tokenIndex138, depth138 := position, tokenIndex, depth
+			position141, tokenIndex141, depth141 := position, tokenIndex, depth
 			{
-				position139 := position
+				position142 := position
 				depth++
 				if buffer[position] != rune('m') {
-					goto l138
+					goto l141
 				}
 				position++
 				if buffer[position] != rune('a') {
-					goto l138
+					goto l141
 				}
 				position++
 				if buffer[position] != rune('p') {
-					goto l138
+					goto l141
 				}
 				position++
 				if buffer[position] != rune('[') {
-					goto l138
+					goto l141
 				}
 				position++
 				if !_rules[ruleExpression]() {
-					goto l138
+					goto l141
 				}
 				if buffer[position] != rune('|') {
-					goto l138
+					goto l141
 				}
 				position++
 				if !_rules[rulews]() {
-					goto l138
+					goto l141
 				}
 				if !_rules[ruleName]() {
-					goto l138
+					goto l141
 				}
 				{
-					position140, tokenIndex140, depth140 := position, tokenIndex, depth
-					if !_rules[rulews]() {
-						goto l140
+					position143, tokenIndex143, depth143 := position, tokenIndex, depth
+					if !_rules[ruleNextName]() {
+						goto l143
 					}
-					if buffer[position] != rune(',') {
-						goto l140
-					}
-					position++
-					if !_rules[rulews]() {
-						goto l140
-					}
-					if !_rules[ruleName]() {
-						goto l140
-					}
-					goto l141
-				l140:
-					position, tokenIndex, depth = position140, tokenIndex140, depth140
+					goto l144
+				l143:
+					position, tokenIndex, depth = position143, tokenIndex143, depth143
 				}
-			l141:
+			l144:
 				if !_rules[rulews]() {
-					goto l138
+					goto l141
 				}
 				if buffer[position] != rune('|') {
-					goto l138
+					goto l141
 				}
 				position++
 				if !_rules[rulews]() {
-					goto l138
+					goto l141
 				}
 				if buffer[position] != rune('-') {
-					goto l138
+					goto l141
 				}
 				position++
 				if buffer[position] != rune('>') {
-					goto l138
+					goto l141
 				}
 				position++
 				if !_rules[ruleExpression]() {
-					goto l138
+					goto l141
 				}
 				if buffer[position] != rune(']') {
-					goto l138
+					goto l141
 				}
 				position++
 				depth--
-				add(ruleMapping, position139)
+				add(ruleMapping, position142)
 			}
 			return true
-		l138:
-			position, tokenIndex, depth = position138, tokenIndex138, depth138
+		l141:
+			position, tokenIndex, depth = position141, tokenIndex141, depth141
 			return false
 		},
-		/* 34 Reference <- <('.'? Key (('.' Key) / ('.' '[' [0-9]+ ']'))*)> */
+		/* 34 Lambda <- <('l' 'a' 'm' 'b' 'd' 'a' (LambdaRef / LambdaExpr))> */
 		func() bool {
-			position142, tokenIndex142, depth142 := position, tokenIndex, depth
+			position145, tokenIndex145, depth145 := position, tokenIndex, depth
 			{
-				position143 := position
+				position146 := position
 				depth++
-				{
-					position144, tokenIndex144, depth144 := position, tokenIndex, depth
-					if buffer[position] != rune('.') {
-						goto l144
-					}
-					position++
+				if buffer[position] != rune('l') {
 					goto l145
-				l144:
-					position, tokenIndex, depth = position144, tokenIndex144, depth144
 				}
-			l145:
-				if !_rules[ruleKey]() {
-					goto l142
+				position++
+				if buffer[position] != rune('a') {
+					goto l145
 				}
-			l146:
+				position++
+				if buffer[position] != rune('m') {
+					goto l145
+				}
+				position++
+				if buffer[position] != rune('b') {
+					goto l145
+				}
+				position++
+				if buffer[position] != rune('d') {
+					goto l145
+				}
+				position++
+				if buffer[position] != rune('a') {
+					goto l145
+				}
+				position++
 				{
 					position147, tokenIndex147, depth147 := position, tokenIndex, depth
-					{
-						position148, tokenIndex148, depth148 := position, tokenIndex, depth
-						if buffer[position] != rune('.') {
-							goto l149
-						}
-						position++
-						if !_rules[ruleKey]() {
-							goto l149
-						}
+					if !_rules[ruleLambdaRef]() {
 						goto l148
-					l149:
-						position, tokenIndex, depth = position148, tokenIndex148, depth148
-						if buffer[position] != rune('.') {
-							goto l147
-						}
-						position++
-						if buffer[position] != rune('[') {
-							goto l147
-						}
-						position++
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l147
-						}
-						position++
-					l150:
-						{
-							position151, tokenIndex151, depth151 := position, tokenIndex, depth
-							if c := buffer[position]; c < rune('0') || c > rune('9') {
-								goto l151
-							}
-							position++
-							goto l150
-						l151:
-							position, tokenIndex, depth = position151, tokenIndex151, depth151
-						}
-						if buffer[position] != rune(']') {
-							goto l147
-						}
-						position++
 					}
+					goto l147
 				l148:
-					goto l146
-				l147:
 					position, tokenIndex, depth = position147, tokenIndex147, depth147
+					if !_rules[ruleLambdaExpr]() {
+						goto l145
+					}
 				}
+			l147:
 				depth--
-				add(ruleReference, position143)
+				add(ruleLambda, position146)
 			}
 			return true
-		l142:
-			position, tokenIndex, depth = position142, tokenIndex142, depth142
+		l145:
+			position, tokenIndex, depth = position145, tokenIndex145, depth145
 			return false
 		},
-		/* 35 Key <- <(([a-z] / [A-Z] / [0-9] / '_') ([a-z] / [A-Z] / [0-9] / '_' / '-')* (':' ([a-z] / [A-Z] / [0-9] / '_') ([a-z] / [A-Z] / [0-9] / '_' / '-')*)?)> */
+		/* 35 LambdaRef <- <(req_ws Expression)> */
 		func() bool {
-			position152, tokenIndex152, depth152 := position, tokenIndex, depth
+			position149, tokenIndex149, depth149 := position, tokenIndex, depth
 			{
-				position153 := position
+				position150 := position
 				depth++
+				if !_rules[rulereq_ws]() {
+					goto l149
+				}
+				if !_rules[ruleExpression]() {
+					goto l149
+				}
+				depth--
+				add(ruleLambdaRef, position150)
+			}
+			return true
+		l149:
+			position, tokenIndex, depth = position149, tokenIndex149, depth149
+			return false
+		},
+		/* 36 LambdaExpr <- <(ws '|' ws Name NextName* ws '|' ws ('-' '>') Expression)> */
+		func() bool {
+			position151, tokenIndex151, depth151 := position, tokenIndex, depth
+			{
+				position152 := position
+				depth++
+				if !_rules[rulews]() {
+					goto l151
+				}
+				if buffer[position] != rune('|') {
+					goto l151
+				}
+				position++
+				if !_rules[rulews]() {
+					goto l151
+				}
+				if !_rules[ruleName]() {
+					goto l151
+				}
+			l153:
 				{
 					position154, tokenIndex154, depth154 := position, tokenIndex, depth
-					if c := buffer[position]; c < rune('a') || c > rune('z') {
-						goto l155
+					if !_rules[ruleNextName]() {
+						goto l154
 					}
-					position++
-					goto l154
-				l155:
+					goto l153
+				l154:
 					position, tokenIndex, depth = position154, tokenIndex154, depth154
-					if c := buffer[position]; c < rune('A') || c > rune('Z') {
-						goto l156
-					}
-					position++
-					goto l154
-				l156:
-					position, tokenIndex, depth = position154, tokenIndex154, depth154
-					if c := buffer[position]; c < rune('0') || c > rune('9') {
-						goto l157
-					}
-					position++
-					goto l154
-				l157:
-					position, tokenIndex, depth = position154, tokenIndex154, depth154
-					if buffer[position] != rune('_') {
-						goto l152
-					}
-					position++
 				}
-			l154:
-			l158:
+				if !_rules[rulews]() {
+					goto l151
+				}
+				if buffer[position] != rune('|') {
+					goto l151
+				}
+				position++
+				if !_rules[rulews]() {
+					goto l151
+				}
+				if buffer[position] != rune('-') {
+					goto l151
+				}
+				position++
+				if buffer[position] != rune('>') {
+					goto l151
+				}
+				position++
+				if !_rules[ruleExpression]() {
+					goto l151
+				}
+				depth--
+				add(ruleLambdaExpr, position152)
+			}
+			return true
+		l151:
+			position, tokenIndex, depth = position151, tokenIndex151, depth151
+			return false
+		},
+		/* 37 NextName <- <(ws ',' ws Name)> */
+		func() bool {
+			position155, tokenIndex155, depth155 := position, tokenIndex, depth
+			{
+				position156 := position
+				depth++
+				if !_rules[rulews]() {
+					goto l155
+				}
+				if buffer[position] != rune(',') {
+					goto l155
+				}
+				position++
+				if !_rules[rulews]() {
+					goto l155
+				}
+				if !_rules[ruleName]() {
+					goto l155
+				}
+				depth--
+				add(ruleNextName, position156)
+			}
+			return true
+		l155:
+			position, tokenIndex, depth = position155, tokenIndex155, depth155
+			return false
+		},
+		/* 38 Reference <- <('.'? Key (('.' Key) / ('.' '[' [0-9]+ ']'))*)> */
+		func() bool {
+			position157, tokenIndex157, depth157 := position, tokenIndex, depth
+			{
+				position158 := position
+				depth++
 				{
 					position159, tokenIndex159, depth159 := position, tokenIndex, depth
-					{
-						position160, tokenIndex160, depth160 := position, tokenIndex, depth
-						if c := buffer[position]; c < rune('a') || c > rune('z') {
-							goto l161
-						}
-						position++
-						goto l160
-					l161:
-						position, tokenIndex, depth = position160, tokenIndex160, depth160
-						if c := buffer[position]; c < rune('A') || c > rune('Z') {
-							goto l162
-						}
-						position++
-						goto l160
-					l162:
-						position, tokenIndex, depth = position160, tokenIndex160, depth160
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l163
-						}
-						position++
-						goto l160
-					l163:
-						position, tokenIndex, depth = position160, tokenIndex160, depth160
-						if buffer[position] != rune('_') {
-							goto l164
-						}
-						position++
-						goto l160
-					l164:
-						position, tokenIndex, depth = position160, tokenIndex160, depth160
-						if buffer[position] != rune('-') {
-							goto l159
-						}
-						position++
+					if buffer[position] != rune('.') {
+						goto l159
 					}
-				l160:
-					goto l158
+					position++
+					goto l160
 				l159:
 					position, tokenIndex, depth = position159, tokenIndex159, depth159
 				}
+			l160:
+				if !_rules[ruleKey]() {
+					goto l157
+				}
+			l161:
 				{
-					position165, tokenIndex165, depth165 := position, tokenIndex, depth
+					position162, tokenIndex162, depth162 := position, tokenIndex, depth
+					{
+						position163, tokenIndex163, depth163 := position, tokenIndex, depth
+						if buffer[position] != rune('.') {
+							goto l164
+						}
+						position++
+						if !_rules[ruleKey]() {
+							goto l164
+						}
+						goto l163
+					l164:
+						position, tokenIndex, depth = position163, tokenIndex163, depth163
+						if buffer[position] != rune('.') {
+							goto l162
+						}
+						position++
+						if buffer[position] != rune('[') {
+							goto l162
+						}
+						position++
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l162
+						}
+						position++
+					l165:
+						{
+							position166, tokenIndex166, depth166 := position, tokenIndex, depth
+							if c := buffer[position]; c < rune('0') || c > rune('9') {
+								goto l166
+							}
+							position++
+							goto l165
+						l166:
+							position, tokenIndex, depth = position166, tokenIndex166, depth166
+						}
+						if buffer[position] != rune(']') {
+							goto l162
+						}
+						position++
+					}
+				l163:
+					goto l161
+				l162:
+					position, tokenIndex, depth = position162, tokenIndex162, depth162
+				}
+				depth--
+				add(ruleReference, position158)
+			}
+			return true
+		l157:
+			position, tokenIndex, depth = position157, tokenIndex157, depth157
+			return false
+		},
+		/* 39 Key <- <(([a-z] / [A-Z] / [0-9] / '_') ([a-z] / [A-Z] / [0-9] / '_' / '-')* (':' ([a-z] / [A-Z] / [0-9] / '_') ([a-z] / [A-Z] / [0-9] / '_' / '-')*)?)> */
+		func() bool {
+			position167, tokenIndex167, depth167 := position, tokenIndex, depth
+			{
+				position168 := position
+				depth++
+				{
+					position169, tokenIndex169, depth169 := position, tokenIndex, depth
+					if c := buffer[position]; c < rune('a') || c > rune('z') {
+						goto l170
+					}
+					position++
+					goto l169
+				l170:
+					position, tokenIndex, depth = position169, tokenIndex169, depth169
+					if c := buffer[position]; c < rune('A') || c > rune('Z') {
+						goto l171
+					}
+					position++
+					goto l169
+				l171:
+					position, tokenIndex, depth = position169, tokenIndex169, depth169
+					if c := buffer[position]; c < rune('0') || c > rune('9') {
+						goto l172
+					}
+					position++
+					goto l169
+				l172:
+					position, tokenIndex, depth = position169, tokenIndex169, depth169
+					if buffer[position] != rune('_') {
+						goto l167
+					}
+					position++
+				}
+			l169:
+			l173:
+				{
+					position174, tokenIndex174, depth174 := position, tokenIndex, depth
+					{
+						position175, tokenIndex175, depth175 := position, tokenIndex, depth
+						if c := buffer[position]; c < rune('a') || c > rune('z') {
+							goto l176
+						}
+						position++
+						goto l175
+					l176:
+						position, tokenIndex, depth = position175, tokenIndex175, depth175
+						if c := buffer[position]; c < rune('A') || c > rune('Z') {
+							goto l177
+						}
+						position++
+						goto l175
+					l177:
+						position, tokenIndex, depth = position175, tokenIndex175, depth175
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l178
+						}
+						position++
+						goto l175
+					l178:
+						position, tokenIndex, depth = position175, tokenIndex175, depth175
+						if buffer[position] != rune('_') {
+							goto l179
+						}
+						position++
+						goto l175
+					l179:
+						position, tokenIndex, depth = position175, tokenIndex175, depth175
+						if buffer[position] != rune('-') {
+							goto l174
+						}
+						position++
+					}
+				l175:
+					goto l173
+				l174:
+					position, tokenIndex, depth = position174, tokenIndex174, depth174
+				}
+				{
+					position180, tokenIndex180, depth180 := position, tokenIndex, depth
 					if buffer[position] != rune(':') {
-						goto l165
+						goto l180
 					}
 					position++
 					{
-						position167, tokenIndex167, depth167 := position, tokenIndex, depth
-						if c := buffer[position]; c < rune('a') || c > rune('z') {
-							goto l168
-						}
-						position++
-						goto l167
-					l168:
-						position, tokenIndex, depth = position167, tokenIndex167, depth167
-						if c := buffer[position]; c < rune('A') || c > rune('Z') {
-							goto l169
-						}
-						position++
-						goto l167
-					l169:
-						position, tokenIndex, depth = position167, tokenIndex167, depth167
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l170
-						}
-						position++
-						goto l167
-					l170:
-						position, tokenIndex, depth = position167, tokenIndex167, depth167
-						if buffer[position] != rune('_') {
-							goto l165
-						}
-						position++
-					}
-				l167:
-				l171:
-					{
-						position172, tokenIndex172, depth172 := position, tokenIndex, depth
-						{
-							position173, tokenIndex173, depth173 := position, tokenIndex, depth
-							if c := buffer[position]; c < rune('a') || c > rune('z') {
-								goto l174
-							}
-							position++
-							goto l173
-						l174:
-							position, tokenIndex, depth = position173, tokenIndex173, depth173
-							if c := buffer[position]; c < rune('A') || c > rune('Z') {
-								goto l175
-							}
-							position++
-							goto l173
-						l175:
-							position, tokenIndex, depth = position173, tokenIndex173, depth173
-							if c := buffer[position]; c < rune('0') || c > rune('9') {
-								goto l176
-							}
-							position++
-							goto l173
-						l176:
-							position, tokenIndex, depth = position173, tokenIndex173, depth173
-							if buffer[position] != rune('_') {
-								goto l177
-							}
-							position++
-							goto l173
-						l177:
-							position, tokenIndex, depth = position173, tokenIndex173, depth173
-							if buffer[position] != rune('-') {
-								goto l172
-							}
-							position++
-						}
-					l173:
-						goto l171
-					l172:
-						position, tokenIndex, depth = position172, tokenIndex172, depth172
-					}
-					goto l166
-				l165:
-					position, tokenIndex, depth = position165, tokenIndex165, depth165
-				}
-			l166:
-				depth--
-				add(ruleKey, position153)
-			}
-			return true
-		l152:
-			position, tokenIndex, depth = position152, tokenIndex152, depth152
-			return false
-		},
-		/* 36 ws <- <(' ' / '\t' / '\n' / '\r')*> */
-		func() bool {
-			{
-				position179 := position
-				depth++
-			l180:
-				{
-					position181, tokenIndex181, depth181 := position, tokenIndex, depth
-					{
 						position182, tokenIndex182, depth182 := position, tokenIndex, depth
-						if buffer[position] != rune(' ') {
+						if c := buffer[position]; c < rune('a') || c > rune('z') {
 							goto l183
 						}
 						position++
 						goto l182
 					l183:
 						position, tokenIndex, depth = position182, tokenIndex182, depth182
-						if buffer[position] != rune('\t') {
+						if c := buffer[position]; c < rune('A') || c > rune('Z') {
 							goto l184
 						}
 						position++
 						goto l182
 					l184:
 						position, tokenIndex, depth = position182, tokenIndex182, depth182
-						if buffer[position] != rune('\n') {
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
 							goto l185
 						}
 						position++
 						goto l182
 					l185:
 						position, tokenIndex, depth = position182, tokenIndex182, depth182
-						if buffer[position] != rune('\r') {
-							goto l181
+						if buffer[position] != rune('_') {
+							goto l180
 						}
 						position++
 					}
 				l182:
-					goto l180
-				l181:
-					position, tokenIndex, depth = position181, tokenIndex181, depth181
+				l186:
+					{
+						position187, tokenIndex187, depth187 := position, tokenIndex, depth
+						{
+							position188, tokenIndex188, depth188 := position, tokenIndex, depth
+							if c := buffer[position]; c < rune('a') || c > rune('z') {
+								goto l189
+							}
+							position++
+							goto l188
+						l189:
+							position, tokenIndex, depth = position188, tokenIndex188, depth188
+							if c := buffer[position]; c < rune('A') || c > rune('Z') {
+								goto l190
+							}
+							position++
+							goto l188
+						l190:
+							position, tokenIndex, depth = position188, tokenIndex188, depth188
+							if c := buffer[position]; c < rune('0') || c > rune('9') {
+								goto l191
+							}
+							position++
+							goto l188
+						l191:
+							position, tokenIndex, depth = position188, tokenIndex188, depth188
+							if buffer[position] != rune('_') {
+								goto l192
+							}
+							position++
+							goto l188
+						l192:
+							position, tokenIndex, depth = position188, tokenIndex188, depth188
+							if buffer[position] != rune('-') {
+								goto l187
+							}
+							position++
+						}
+					l188:
+						goto l186
+					l187:
+						position, tokenIndex, depth = position187, tokenIndex187, depth187
+					}
+					goto l181
+				l180:
+					position, tokenIndex, depth = position180, tokenIndex180, depth180
 				}
+			l181:
 				depth--
-				add(rulews, position179)
+				add(ruleKey, position168)
 			}
 			return true
+		l167:
+			position, tokenIndex, depth = position167, tokenIndex167, depth167
+			return false
 		},
-		/* 37 req_ws <- <(' ' / '\t' / '\n' / '\r')+> */
+		/* 40 ws <- <(' ' / '\t' / '\n' / '\r')*> */
 		func() bool {
-			position186, tokenIndex186, depth186 := position, tokenIndex, depth
 			{
-				position187 := position
+				position194 := position
 				depth++
+			l195:
 				{
-					position190, tokenIndex190, depth190 := position, tokenIndex, depth
-					if buffer[position] != rune(' ') {
-						goto l191
-					}
-					position++
-					goto l190
-				l191:
-					position, tokenIndex, depth = position190, tokenIndex190, depth190
-					if buffer[position] != rune('\t') {
-						goto l192
-					}
-					position++
-					goto l190
-				l192:
-					position, tokenIndex, depth = position190, tokenIndex190, depth190
-					if buffer[position] != rune('\n') {
-						goto l193
-					}
-					position++
-					goto l190
-				l193:
-					position, tokenIndex, depth = position190, tokenIndex190, depth190
-					if buffer[position] != rune('\r') {
-						goto l186
-					}
-					position++
-				}
-			l190:
-			l188:
-				{
-					position189, tokenIndex189, depth189 := position, tokenIndex, depth
+					position196, tokenIndex196, depth196 := position, tokenIndex, depth
 					{
-						position194, tokenIndex194, depth194 := position, tokenIndex, depth
+						position197, tokenIndex197, depth197 := position, tokenIndex, depth
 						if buffer[position] != rune(' ') {
-							goto l195
+							goto l198
 						}
 						position++
-						goto l194
-					l195:
-						position, tokenIndex, depth = position194, tokenIndex194, depth194
+						goto l197
+					l198:
+						position, tokenIndex, depth = position197, tokenIndex197, depth197
 						if buffer[position] != rune('\t') {
+							goto l199
+						}
+						position++
+						goto l197
+					l199:
+						position, tokenIndex, depth = position197, tokenIndex197, depth197
+						if buffer[position] != rune('\n') {
+							goto l200
+						}
+						position++
+						goto l197
+					l200:
+						position, tokenIndex, depth = position197, tokenIndex197, depth197
+						if buffer[position] != rune('\r') {
 							goto l196
 						}
 						position++
-						goto l194
-					l196:
-						position, tokenIndex, depth = position194, tokenIndex194, depth194
-						if buffer[position] != rune('\n') {
-							goto l197
+					}
+				l197:
+					goto l195
+				l196:
+					position, tokenIndex, depth = position196, tokenIndex196, depth196
+				}
+				depth--
+				add(rulews, position194)
+			}
+			return true
+		},
+		/* 41 req_ws <- <(' ' / '\t' / '\n' / '\r')+> */
+		func() bool {
+			position201, tokenIndex201, depth201 := position, tokenIndex, depth
+			{
+				position202 := position
+				depth++
+				{
+					position205, tokenIndex205, depth205 := position, tokenIndex, depth
+					if buffer[position] != rune(' ') {
+						goto l206
+					}
+					position++
+					goto l205
+				l206:
+					position, tokenIndex, depth = position205, tokenIndex205, depth205
+					if buffer[position] != rune('\t') {
+						goto l207
+					}
+					position++
+					goto l205
+				l207:
+					position, tokenIndex, depth = position205, tokenIndex205, depth205
+					if buffer[position] != rune('\n') {
+						goto l208
+					}
+					position++
+					goto l205
+				l208:
+					position, tokenIndex, depth = position205, tokenIndex205, depth205
+					if buffer[position] != rune('\r') {
+						goto l201
+					}
+					position++
+				}
+			l205:
+			l203:
+				{
+					position204, tokenIndex204, depth204 := position, tokenIndex, depth
+					{
+						position209, tokenIndex209, depth209 := position, tokenIndex, depth
+						if buffer[position] != rune(' ') {
+							goto l210
 						}
 						position++
-						goto l194
-					l197:
-						position, tokenIndex, depth = position194, tokenIndex194, depth194
+						goto l209
+					l210:
+						position, tokenIndex, depth = position209, tokenIndex209, depth209
+						if buffer[position] != rune('\t') {
+							goto l211
+						}
+						position++
+						goto l209
+					l211:
+						position, tokenIndex, depth = position209, tokenIndex209, depth209
+						if buffer[position] != rune('\n') {
+							goto l212
+						}
+						position++
+						goto l209
+					l212:
+						position, tokenIndex, depth = position209, tokenIndex209, depth209
 						if buffer[position] != rune('\r') {
-							goto l189
+							goto l204
 						}
 						position++
 					}
-				l194:
-					goto l188
-				l189:
-					position, tokenIndex, depth = position189, tokenIndex189, depth189
+				l209:
+					goto l203
+				l204:
+					position, tokenIndex, depth = position204, tokenIndex204, depth204
 				}
 				depth--
-				add(rulereq_ws, position187)
+				add(rulereq_ws, position202)
 			}
 			return true
-		l186:
-			position, tokenIndex, depth = position186, tokenIndex186, depth186
+		l201:
+			position, tokenIndex, depth = position201, tokenIndex201, depth201
 			return false
 		},
 	}

--- a/dynaml/dynaml.peg.go
+++ b/dynaml/dynaml.peg.go
@@ -37,14 +37,14 @@ const (
 	ruleDivision
 	ruleModulo
 	ruleLevel0
-	ruleQualifiedExpression
+	ruleChained
+	ruleChainedQualifiedExpression
+	ruleChainedCall
+	ruleArguments
+	ruleNextExpression
 	ruleNot
 	ruleGrouped
 	ruleRange
-	ruleCall
-	ruleName
-	ruleArguments
-	ruleNextExpression
 	ruleInteger
 	ruleString
 	ruleBoolean
@@ -63,6 +63,7 @@ const (
 	ruleLambdaRef
 	ruleLambdaExpr
 	ruleNextName
+	ruleName
 	ruleReference
 	ruleFollowUpRef
 	ruleKey
@@ -100,14 +101,14 @@ var rul3s = [...]string{
 	"Division",
 	"Modulo",
 	"Level0",
-	"QualifiedExpression",
+	"Chained",
+	"ChainedQualifiedExpression",
+	"ChainedCall",
+	"Arguments",
+	"NextExpression",
 	"Not",
 	"Grouped",
 	"Range",
-	"Call",
-	"Name",
-	"Arguments",
-	"NextExpression",
 	"Integer",
 	"String",
 	"Boolean",
@@ -126,6 +127,7 @@ var rul3s = [...]string{
 	"LambdaRef",
 	"LambdaExpr",
 	"NextName",
+	"Name",
 	"Reference",
 	"FollowUpRef",
 	"Key",
@@ -450,7 +452,7 @@ func (t *tokens32) Expand(index int) tokenTree {
 type DynamlGrammar struct {
 	Buffer string
 	buffer []rune
-	rules  [56]func() bool
+	rules  [57]func() bool
 	Parse  func(rule ...int) error
 	Reset  func()
 	tokenTree
@@ -1309,7 +1311,7 @@ func (p *DynamlGrammar) Init() {
 			position, tokenIndex, depth = position75, tokenIndex75, depth75
 			return false
 		},
-		/* 22 Level0 <- <(QualifiedExpression / Not / Call / Grouped / Boolean / Nil / String / Integer / List / Range / Merge / Auto / Mapping / Lambda / Reference)> */
+		/* 22 Level0 <- <(String / Integer / Boolean / Nil / Not / Merge / Auto / Lambda / Chained)> */
 		func() bool {
 			position77, tokenIndex77, depth77 := position, tokenIndex, depth
 			{
@@ -1317,91 +1319,55 @@ func (p *DynamlGrammar) Init() {
 				depth++
 				{
 					position79, tokenIndex79, depth79 := position, tokenIndex, depth
-					if !_rules[ruleQualifiedExpression]() {
+					if !_rules[ruleString]() {
 						goto l80
 					}
 					goto l79
 				l80:
 					position, tokenIndex, depth = position79, tokenIndex79, depth79
-					if !_rules[ruleNot]() {
+					if !_rules[ruleInteger]() {
 						goto l81
 					}
 					goto l79
 				l81:
 					position, tokenIndex, depth = position79, tokenIndex79, depth79
-					if !_rules[ruleCall]() {
+					if !_rules[ruleBoolean]() {
 						goto l82
 					}
 					goto l79
 				l82:
 					position, tokenIndex, depth = position79, tokenIndex79, depth79
-					if !_rules[ruleGrouped]() {
+					if !_rules[ruleNil]() {
 						goto l83
 					}
 					goto l79
 				l83:
 					position, tokenIndex, depth = position79, tokenIndex79, depth79
-					if !_rules[ruleBoolean]() {
+					if !_rules[ruleNot]() {
 						goto l84
 					}
 					goto l79
 				l84:
 					position, tokenIndex, depth = position79, tokenIndex79, depth79
-					if !_rules[ruleNil]() {
+					if !_rules[ruleMerge]() {
 						goto l85
 					}
 					goto l79
 				l85:
 					position, tokenIndex, depth = position79, tokenIndex79, depth79
-					if !_rules[ruleString]() {
+					if !_rules[ruleAuto]() {
 						goto l86
 					}
 					goto l79
 				l86:
 					position, tokenIndex, depth = position79, tokenIndex79, depth79
-					if !_rules[ruleInteger]() {
+					if !_rules[ruleLambda]() {
 						goto l87
 					}
 					goto l79
 				l87:
 					position, tokenIndex, depth = position79, tokenIndex79, depth79
-					if !_rules[ruleList]() {
-						goto l88
-					}
-					goto l79
-				l88:
-					position, tokenIndex, depth = position79, tokenIndex79, depth79
-					if !_rules[ruleRange]() {
-						goto l89
-					}
-					goto l79
-				l89:
-					position, tokenIndex, depth = position79, tokenIndex79, depth79
-					if !_rules[ruleMerge]() {
-						goto l90
-					}
-					goto l79
-				l90:
-					position, tokenIndex, depth = position79, tokenIndex79, depth79
-					if !_rules[ruleAuto]() {
-						goto l91
-					}
-					goto l79
-				l91:
-					position, tokenIndex, depth = position79, tokenIndex79, depth79
-					if !_rules[ruleMapping]() {
-						goto l92
-					}
-					goto l79
-				l92:
-					position, tokenIndex, depth = position79, tokenIndex79, depth79
-					if !_rules[ruleLambda]() {
-						goto l93
-					}
-					goto l79
-				l93:
-					position, tokenIndex, depth = position79, tokenIndex79, depth79
-					if !_rules[ruleReference]() {
+					if !_rules[ruleChained]() {
 						goto l77
 					}
 				}
@@ -1414,156 +1380,125 @@ func (p *DynamlGrammar) Init() {
 			position, tokenIndex, depth = position77, tokenIndex77, depth77
 			return false
 		},
-		/* 23 QualifiedExpression <- <((Call / Grouped / List / Range) '.' FollowUpRef)> */
+		/* 23 Chained <- <((Mapping / List / Range / ((Grouped / Reference) ChainedCall*)) (ChainedQualifiedExpression ChainedCall+)* ChainedQualifiedExpression?)> */
 		func() bool {
-			position94, tokenIndex94, depth94 := position, tokenIndex, depth
+			position88, tokenIndex88, depth88 := position, tokenIndex, depth
 			{
-				position95 := position
+				position89 := position
 				depth++
 				{
-					position96, tokenIndex96, depth96 := position, tokenIndex, depth
-					if !_rules[ruleCall]() {
-						goto l97
+					position90, tokenIndex90, depth90 := position, tokenIndex, depth
+					if !_rules[ruleMapping]() {
+						goto l91
 					}
-					goto l96
-				l97:
-					position, tokenIndex, depth = position96, tokenIndex96, depth96
-					if !_rules[ruleGrouped]() {
-						goto l98
-					}
-					goto l96
-				l98:
-					position, tokenIndex, depth = position96, tokenIndex96, depth96
+					goto l90
+				l91:
+					position, tokenIndex, depth = position90, tokenIndex90, depth90
 					if !_rules[ruleList]() {
+						goto l92
+					}
+					goto l90
+				l92:
+					position, tokenIndex, depth = position90, tokenIndex90, depth90
+					if !_rules[ruleRange]() {
+						goto l93
+					}
+					goto l90
+				l93:
+					position, tokenIndex, depth = position90, tokenIndex90, depth90
+					{
+						position94, tokenIndex94, depth94 := position, tokenIndex, depth
+						if !_rules[ruleGrouped]() {
+							goto l95
+						}
+						goto l94
+					l95:
+						position, tokenIndex, depth = position94, tokenIndex94, depth94
+						if !_rules[ruleReference]() {
+							goto l88
+						}
+					}
+				l94:
+				l96:
+					{
+						position97, tokenIndex97, depth97 := position, tokenIndex, depth
+						if !_rules[ruleChainedCall]() {
+							goto l97
+						}
+						goto l96
+					l97:
+						position, tokenIndex, depth = position97, tokenIndex97, depth97
+					}
+				}
+			l90:
+			l98:
+				{
+					position99, tokenIndex99, depth99 := position, tokenIndex, depth
+					if !_rules[ruleChainedQualifiedExpression]() {
 						goto l99
 					}
-					goto l96
-				l99:
-					position, tokenIndex, depth = position96, tokenIndex96, depth96
-					if !_rules[ruleRange]() {
-						goto l94
+					if !_rules[ruleChainedCall]() {
+						goto l99
 					}
+				l100:
+					{
+						position101, tokenIndex101, depth101 := position, tokenIndex, depth
+						if !_rules[ruleChainedCall]() {
+							goto l101
+						}
+						goto l100
+					l101:
+						position, tokenIndex, depth = position101, tokenIndex101, depth101
+					}
+					goto l98
+				l99:
+					position, tokenIndex, depth = position99, tokenIndex99, depth99
 				}
-			l96:
-				if buffer[position] != rune('.') {
-					goto l94
+				{
+					position102, tokenIndex102, depth102 := position, tokenIndex, depth
+					if !_rules[ruleChainedQualifiedExpression]() {
+						goto l102
+					}
+					goto l103
+				l102:
+					position, tokenIndex, depth = position102, tokenIndex102, depth102
 				}
-				position++
-				if !_rules[ruleFollowUpRef]() {
-					goto l94
-				}
+			l103:
 				depth--
-				add(ruleQualifiedExpression, position95)
+				add(ruleChained, position89)
 			}
 			return true
-		l94:
-			position, tokenIndex, depth = position94, tokenIndex94, depth94
+		l88:
+			position, tokenIndex, depth = position88, tokenIndex88, depth88
 			return false
 		},
-		/* 24 Not <- <('!' ws Level0)> */
-		func() bool {
-			position100, tokenIndex100, depth100 := position, tokenIndex, depth
-			{
-				position101 := position
-				depth++
-				if buffer[position] != rune('!') {
-					goto l100
-				}
-				position++
-				if !_rules[rulews]() {
-					goto l100
-				}
-				if !_rules[ruleLevel0]() {
-					goto l100
-				}
-				depth--
-				add(ruleNot, position101)
-			}
-			return true
-		l100:
-			position, tokenIndex, depth = position100, tokenIndex100, depth100
-			return false
-		},
-		/* 25 Grouped <- <('(' Expression ')')> */
-		func() bool {
-			position102, tokenIndex102, depth102 := position, tokenIndex, depth
-			{
-				position103 := position
-				depth++
-				if buffer[position] != rune('(') {
-					goto l102
-				}
-				position++
-				if !_rules[ruleExpression]() {
-					goto l102
-				}
-				if buffer[position] != rune(')') {
-					goto l102
-				}
-				position++
-				depth--
-				add(ruleGrouped, position103)
-			}
-			return true
-		l102:
-			position, tokenIndex, depth = position102, tokenIndex102, depth102
-			return false
-		},
-		/* 26 Range <- <('[' Expression ('.' '.') Expression ']')> */
+		/* 24 ChainedQualifiedExpression <- <('.' FollowUpRef)> */
 		func() bool {
 			position104, tokenIndex104, depth104 := position, tokenIndex, depth
 			{
 				position105 := position
 				depth++
-				if buffer[position] != rune('[') {
-					goto l104
-				}
-				position++
-				if !_rules[ruleExpression]() {
-					goto l104
-				}
 				if buffer[position] != rune('.') {
 					goto l104
 				}
 				position++
-				if buffer[position] != rune('.') {
+				if !_rules[ruleFollowUpRef]() {
 					goto l104
 				}
-				position++
-				if !_rules[ruleExpression]() {
-					goto l104
-				}
-				if buffer[position] != rune(']') {
-					goto l104
-				}
-				position++
 				depth--
-				add(ruleRange, position105)
+				add(ruleChainedQualifiedExpression, position105)
 			}
 			return true
 		l104:
 			position, tokenIndex, depth = position104, tokenIndex104, depth104
 			return false
 		},
-		/* 27 Call <- <((Reference / Grouped) '(' Arguments ')')> */
+		/* 25 ChainedCall <- <('(' Arguments ')')> */
 		func() bool {
 			position106, tokenIndex106, depth106 := position, tokenIndex, depth
 			{
 				position107 := position
 				depth++
-				{
-					position108, tokenIndex108, depth108 := position, tokenIndex, depth
-					if !_rules[ruleReference]() {
-						goto l109
-					}
-					goto l108
-				l109:
-					position, tokenIndex, depth = position108, tokenIndex108, depth108
-					if !_rules[ruleGrouped]() {
-						goto l106
-					}
-				}
-			l108:
 				if buffer[position] != rune('(') {
 					goto l106
 				}
@@ -1576,650 +1511,791 @@ func (p *DynamlGrammar) Init() {
 				}
 				position++
 				depth--
-				add(ruleCall, position107)
+				add(ruleChainedCall, position107)
 			}
 			return true
 		l106:
 			position, tokenIndex, depth = position106, tokenIndex106, depth106
 			return false
 		},
-		/* 28 Name <- <([a-z] / [A-Z] / [0-9] / '_')+> */
+		/* 26 Arguments <- <(Expression NextExpression*)> */
 		func() bool {
-			position110, tokenIndex110, depth110 := position, tokenIndex, depth
+			position108, tokenIndex108, depth108 := position, tokenIndex, depth
 			{
-				position111 := position
-				depth++
-				{
-					position114, tokenIndex114, depth114 := position, tokenIndex, depth
-					if c := buffer[position]; c < rune('a') || c > rune('z') {
-						goto l115
-					}
-					position++
-					goto l114
-				l115:
-					position, tokenIndex, depth = position114, tokenIndex114, depth114
-					if c := buffer[position]; c < rune('A') || c > rune('Z') {
-						goto l116
-					}
-					position++
-					goto l114
-				l116:
-					position, tokenIndex, depth = position114, tokenIndex114, depth114
-					if c := buffer[position]; c < rune('0') || c > rune('9') {
-						goto l117
-					}
-					position++
-					goto l114
-				l117:
-					position, tokenIndex, depth = position114, tokenIndex114, depth114
-					if buffer[position] != rune('_') {
-						goto l110
-					}
-					position++
-				}
-			l114:
-			l112:
-				{
-					position113, tokenIndex113, depth113 := position, tokenIndex, depth
-					{
-						position118, tokenIndex118, depth118 := position, tokenIndex, depth
-						if c := buffer[position]; c < rune('a') || c > rune('z') {
-							goto l119
-						}
-						position++
-						goto l118
-					l119:
-						position, tokenIndex, depth = position118, tokenIndex118, depth118
-						if c := buffer[position]; c < rune('A') || c > rune('Z') {
-							goto l120
-						}
-						position++
-						goto l118
-					l120:
-						position, tokenIndex, depth = position118, tokenIndex118, depth118
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l121
-						}
-						position++
-						goto l118
-					l121:
-						position, tokenIndex, depth = position118, tokenIndex118, depth118
-						if buffer[position] != rune('_') {
-							goto l113
-						}
-						position++
-					}
-				l118:
-					goto l112
-				l113:
-					position, tokenIndex, depth = position113, tokenIndex113, depth113
-				}
-				depth--
-				add(ruleName, position111)
-			}
-			return true
-		l110:
-			position, tokenIndex, depth = position110, tokenIndex110, depth110
-			return false
-		},
-		/* 29 Arguments <- <(Expression NextExpression*)> */
-		func() bool {
-			position122, tokenIndex122, depth122 := position, tokenIndex, depth
-			{
-				position123 := position
+				position109 := position
 				depth++
 				if !_rules[ruleExpression]() {
-					goto l122
+					goto l108
 				}
+			l110:
+				{
+					position111, tokenIndex111, depth111 := position, tokenIndex, depth
+					if !_rules[ruleNextExpression]() {
+						goto l111
+					}
+					goto l110
+				l111:
+					position, tokenIndex, depth = position111, tokenIndex111, depth111
+				}
+				depth--
+				add(ruleArguments, position109)
+			}
+			return true
+		l108:
+			position, tokenIndex, depth = position108, tokenIndex108, depth108
+			return false
+		},
+		/* 27 NextExpression <- <(',' Expression)> */
+		func() bool {
+			position112, tokenIndex112, depth112 := position, tokenIndex, depth
+			{
+				position113 := position
+				depth++
+				if buffer[position] != rune(',') {
+					goto l112
+				}
+				position++
+				if !_rules[ruleExpression]() {
+					goto l112
+				}
+				depth--
+				add(ruleNextExpression, position113)
+			}
+			return true
+		l112:
+			position, tokenIndex, depth = position112, tokenIndex112, depth112
+			return false
+		},
+		/* 28 Not <- <('!' ws Level0)> */
+		func() bool {
+			position114, tokenIndex114, depth114 := position, tokenIndex, depth
+			{
+				position115 := position
+				depth++
+				if buffer[position] != rune('!') {
+					goto l114
+				}
+				position++
+				if !_rules[rulews]() {
+					goto l114
+				}
+				if !_rules[ruleLevel0]() {
+					goto l114
+				}
+				depth--
+				add(ruleNot, position115)
+			}
+			return true
+		l114:
+			position, tokenIndex, depth = position114, tokenIndex114, depth114
+			return false
+		},
+		/* 29 Grouped <- <('(' Expression ')')> */
+		func() bool {
+			position116, tokenIndex116, depth116 := position, tokenIndex, depth
+			{
+				position117 := position
+				depth++
+				if buffer[position] != rune('(') {
+					goto l116
+				}
+				position++
+				if !_rules[ruleExpression]() {
+					goto l116
+				}
+				if buffer[position] != rune(')') {
+					goto l116
+				}
+				position++
+				depth--
+				add(ruleGrouped, position117)
+			}
+			return true
+		l116:
+			position, tokenIndex, depth = position116, tokenIndex116, depth116
+			return false
+		},
+		/* 30 Range <- <('[' Expression ('.' '.') Expression ']')> */
+		func() bool {
+			position118, tokenIndex118, depth118 := position, tokenIndex, depth
+			{
+				position119 := position
+				depth++
+				if buffer[position] != rune('[') {
+					goto l118
+				}
+				position++
+				if !_rules[ruleExpression]() {
+					goto l118
+				}
+				if buffer[position] != rune('.') {
+					goto l118
+				}
+				position++
+				if buffer[position] != rune('.') {
+					goto l118
+				}
+				position++
+				if !_rules[ruleExpression]() {
+					goto l118
+				}
+				if buffer[position] != rune(']') {
+					goto l118
+				}
+				position++
+				depth--
+				add(ruleRange, position119)
+			}
+			return true
+		l118:
+			position, tokenIndex, depth = position118, tokenIndex118, depth118
+			return false
+		},
+		/* 31 Integer <- <('-'? [0-9] ([0-9] / '_')*)> */
+		func() bool {
+			position120, tokenIndex120, depth120 := position, tokenIndex, depth
+			{
+				position121 := position
+				depth++
+				{
+					position122, tokenIndex122, depth122 := position, tokenIndex, depth
+					if buffer[position] != rune('-') {
+						goto l122
+					}
+					position++
+					goto l123
+				l122:
+					position, tokenIndex, depth = position122, tokenIndex122, depth122
+				}
+			l123:
+				if c := buffer[position]; c < rune('0') || c > rune('9') {
+					goto l120
+				}
+				position++
 			l124:
 				{
 					position125, tokenIndex125, depth125 := position, tokenIndex, depth
-					if !_rules[ruleNextExpression]() {
-						goto l125
+					{
+						position126, tokenIndex126, depth126 := position, tokenIndex, depth
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l127
+						}
+						position++
+						goto l126
+					l127:
+						position, tokenIndex, depth = position126, tokenIndex126, depth126
+						if buffer[position] != rune('_') {
+							goto l125
+						}
+						position++
 					}
+				l126:
 					goto l124
 				l125:
 					position, tokenIndex, depth = position125, tokenIndex125, depth125
 				}
 				depth--
-				add(ruleArguments, position123)
+				add(ruleInteger, position121)
 			}
 			return true
-		l122:
-			position, tokenIndex, depth = position122, tokenIndex122, depth122
+		l120:
+			position, tokenIndex, depth = position120, tokenIndex120, depth120
 			return false
 		},
-		/* 30 NextExpression <- <(',' Expression)> */
-		func() bool {
-			position126, tokenIndex126, depth126 := position, tokenIndex, depth
-			{
-				position127 := position
-				depth++
-				if buffer[position] != rune(',') {
-					goto l126
-				}
-				position++
-				if !_rules[ruleExpression]() {
-					goto l126
-				}
-				depth--
-				add(ruleNextExpression, position127)
-			}
-			return true
-		l126:
-			position, tokenIndex, depth = position126, tokenIndex126, depth126
-			return false
-		},
-		/* 31 Integer <- <('-'? ([0-9] / '_')+)> */
+		/* 32 String <- <('"' (('\\' '"') / (!'"' .))* '"')> */
 		func() bool {
 			position128, tokenIndex128, depth128 := position, tokenIndex, depth
 			{
 				position129 := position
 				depth++
-				{
-					position130, tokenIndex130, depth130 := position, tokenIndex, depth
-					if buffer[position] != rune('-') {
-						goto l130
-					}
-					position++
-					goto l131
-				l130:
-					position, tokenIndex, depth = position130, tokenIndex130, depth130
+				if buffer[position] != rune('"') {
+					goto l128
 				}
-			l131:
+				position++
+			l130:
 				{
-					position134, tokenIndex134, depth134 := position, tokenIndex, depth
-					if c := buffer[position]; c < rune('0') || c > rune('9') {
-						goto l135
-					}
-					position++
-					goto l134
-				l135:
-					position, tokenIndex, depth = position134, tokenIndex134, depth134
-					if buffer[position] != rune('_') {
-						goto l128
-					}
-					position++
-				}
-			l134:
-			l132:
-				{
-					position133, tokenIndex133, depth133 := position, tokenIndex, depth
+					position131, tokenIndex131, depth131 := position, tokenIndex, depth
 					{
-						position136, tokenIndex136, depth136 := position, tokenIndex, depth
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l137
-						}
-						position++
-						goto l136
-					l137:
-						position, tokenIndex, depth = position136, tokenIndex136, depth136
-						if buffer[position] != rune('_') {
+						position132, tokenIndex132, depth132 := position, tokenIndex, depth
+						if buffer[position] != rune('\\') {
 							goto l133
 						}
 						position++
+						if buffer[position] != rune('"') {
+							goto l133
+						}
+						position++
+						goto l132
+					l133:
+						position, tokenIndex, depth = position132, tokenIndex132, depth132
+						{
+							position134, tokenIndex134, depth134 := position, tokenIndex, depth
+							if buffer[position] != rune('"') {
+								goto l134
+							}
+							position++
+							goto l131
+						l134:
+							position, tokenIndex, depth = position134, tokenIndex134, depth134
+						}
+						if !matchDot() {
+							goto l131
+						}
 					}
-				l136:
-					goto l132
-				l133:
-					position, tokenIndex, depth = position133, tokenIndex133, depth133
+				l132:
+					goto l130
+				l131:
+					position, tokenIndex, depth = position131, tokenIndex131, depth131
 				}
+				if buffer[position] != rune('"') {
+					goto l128
+				}
+				position++
 				depth--
-				add(ruleInteger, position129)
+				add(ruleString, position129)
 			}
 			return true
 		l128:
 			position, tokenIndex, depth = position128, tokenIndex128, depth128
 			return false
 		},
-		/* 32 String <- <('"' (('\\' '"') / (!'"' .))* '"')> */
-		func() bool {
-			position138, tokenIndex138, depth138 := position, tokenIndex, depth
-			{
-				position139 := position
-				depth++
-				if buffer[position] != rune('"') {
-					goto l138
-				}
-				position++
-			l140:
-				{
-					position141, tokenIndex141, depth141 := position, tokenIndex, depth
-					{
-						position142, tokenIndex142, depth142 := position, tokenIndex, depth
-						if buffer[position] != rune('\\') {
-							goto l143
-						}
-						position++
-						if buffer[position] != rune('"') {
-							goto l143
-						}
-						position++
-						goto l142
-					l143:
-						position, tokenIndex, depth = position142, tokenIndex142, depth142
-						{
-							position144, tokenIndex144, depth144 := position, tokenIndex, depth
-							if buffer[position] != rune('"') {
-								goto l144
-							}
-							position++
-							goto l141
-						l144:
-							position, tokenIndex, depth = position144, tokenIndex144, depth144
-						}
-						if !matchDot() {
-							goto l141
-						}
-					}
-				l142:
-					goto l140
-				l141:
-					position, tokenIndex, depth = position141, tokenIndex141, depth141
-				}
-				if buffer[position] != rune('"') {
-					goto l138
-				}
-				position++
-				depth--
-				add(ruleString, position139)
-			}
-			return true
-		l138:
-			position, tokenIndex, depth = position138, tokenIndex138, depth138
-			return false
-		},
 		/* 33 Boolean <- <(('t' 'r' 'u' 'e') / ('f' 'a' 'l' 's' 'e'))> */
 		func() bool {
-			position145, tokenIndex145, depth145 := position, tokenIndex, depth
+			position135, tokenIndex135, depth135 := position, tokenIndex, depth
 			{
-				position146 := position
+				position136 := position
 				depth++
 				{
-					position147, tokenIndex147, depth147 := position, tokenIndex, depth
+					position137, tokenIndex137, depth137 := position, tokenIndex, depth
 					if buffer[position] != rune('t') {
-						goto l148
+						goto l138
 					}
 					position++
 					if buffer[position] != rune('r') {
-						goto l148
+						goto l138
 					}
 					position++
 					if buffer[position] != rune('u') {
-						goto l148
+						goto l138
 					}
 					position++
 					if buffer[position] != rune('e') {
-						goto l148
+						goto l138
 					}
 					position++
-					goto l147
-				l148:
-					position, tokenIndex, depth = position147, tokenIndex147, depth147
+					goto l137
+				l138:
+					position, tokenIndex, depth = position137, tokenIndex137, depth137
 					if buffer[position] != rune('f') {
-						goto l145
+						goto l135
 					}
 					position++
 					if buffer[position] != rune('a') {
-						goto l145
+						goto l135
 					}
 					position++
 					if buffer[position] != rune('l') {
-						goto l145
+						goto l135
 					}
 					position++
 					if buffer[position] != rune('s') {
-						goto l145
+						goto l135
 					}
 					position++
 					if buffer[position] != rune('e') {
-						goto l145
+						goto l135
 					}
 					position++
 				}
-			l147:
+			l137:
 				depth--
-				add(ruleBoolean, position146)
+				add(ruleBoolean, position136)
 			}
 			return true
-		l145:
-			position, tokenIndex, depth = position145, tokenIndex145, depth145
+		l135:
+			position, tokenIndex, depth = position135, tokenIndex135, depth135
 			return false
 		},
 		/* 34 Nil <- <(('n' 'i' 'l') / '~')> */
 		func() bool {
-			position149, tokenIndex149, depth149 := position, tokenIndex, depth
+			position139, tokenIndex139, depth139 := position, tokenIndex, depth
 			{
-				position150 := position
+				position140 := position
 				depth++
 				{
-					position151, tokenIndex151, depth151 := position, tokenIndex, depth
+					position141, tokenIndex141, depth141 := position, tokenIndex, depth
 					if buffer[position] != rune('n') {
-						goto l152
+						goto l142
 					}
 					position++
 					if buffer[position] != rune('i') {
-						goto l152
+						goto l142
 					}
 					position++
 					if buffer[position] != rune('l') {
-						goto l152
+						goto l142
 					}
 					position++
-					goto l151
-				l152:
-					position, tokenIndex, depth = position151, tokenIndex151, depth151
+					goto l141
+				l142:
+					position, tokenIndex, depth = position141, tokenIndex141, depth141
 					if buffer[position] != rune('~') {
-						goto l149
+						goto l139
 					}
 					position++
 				}
-			l151:
+			l141:
 				depth--
-				add(ruleNil, position150)
+				add(ruleNil, position140)
 			}
 			return true
-		l149:
-			position, tokenIndex, depth = position149, tokenIndex149, depth149
+		l139:
+			position, tokenIndex, depth = position139, tokenIndex139, depth139
 			return false
 		},
 		/* 35 List <- <('[' Contents? ']')> */
 		func() bool {
-			position153, tokenIndex153, depth153 := position, tokenIndex, depth
+			position143, tokenIndex143, depth143 := position, tokenIndex, depth
 			{
-				position154 := position
+				position144 := position
 				depth++
 				if buffer[position] != rune('[') {
-					goto l153
+					goto l143
 				}
 				position++
 				{
-					position155, tokenIndex155, depth155 := position, tokenIndex, depth
+					position145, tokenIndex145, depth145 := position, tokenIndex, depth
 					if !_rules[ruleContents]() {
-						goto l155
+						goto l145
 					}
-					goto l156
-				l155:
-					position, tokenIndex, depth = position155, tokenIndex155, depth155
+					goto l146
+				l145:
+					position, tokenIndex, depth = position145, tokenIndex145, depth145
 				}
-			l156:
+			l146:
 				if buffer[position] != rune(']') {
-					goto l153
+					goto l143
 				}
 				position++
 				depth--
-				add(ruleList, position154)
+				add(ruleList, position144)
 			}
 			return true
-		l153:
-			position, tokenIndex, depth = position153, tokenIndex153, depth153
+		l143:
+			position, tokenIndex, depth = position143, tokenIndex143, depth143
 			return false
 		},
 		/* 36 Contents <- <(Expression NextExpression*)> */
 		func() bool {
-			position157, tokenIndex157, depth157 := position, tokenIndex, depth
+			position147, tokenIndex147, depth147 := position, tokenIndex, depth
 			{
-				position158 := position
+				position148 := position
 				depth++
 				if !_rules[ruleExpression]() {
-					goto l157
+					goto l147
 				}
-			l159:
+			l149:
 				{
-					position160, tokenIndex160, depth160 := position, tokenIndex, depth
+					position150, tokenIndex150, depth150 := position, tokenIndex, depth
 					if !_rules[ruleNextExpression]() {
-						goto l160
+						goto l150
 					}
-					goto l159
-				l160:
-					position, tokenIndex, depth = position160, tokenIndex160, depth160
+					goto l149
+				l150:
+					position, tokenIndex, depth = position150, tokenIndex150, depth150
 				}
 				depth--
-				add(ruleContents, position158)
+				add(ruleContents, position148)
 			}
 			return true
-		l157:
-			position, tokenIndex, depth = position157, tokenIndex157, depth157
+		l147:
+			position, tokenIndex, depth = position147, tokenIndex147, depth147
 			return false
 		},
 		/* 37 Merge <- <(RefMerge / SimpleMerge)> */
 		func() bool {
-			position161, tokenIndex161, depth161 := position, tokenIndex, depth
+			position151, tokenIndex151, depth151 := position, tokenIndex, depth
 			{
-				position162 := position
+				position152 := position
 				depth++
 				{
-					position163, tokenIndex163, depth163 := position, tokenIndex, depth
+					position153, tokenIndex153, depth153 := position, tokenIndex, depth
 					if !_rules[ruleRefMerge]() {
-						goto l164
+						goto l154
 					}
-					goto l163
-				l164:
-					position, tokenIndex, depth = position163, tokenIndex163, depth163
+					goto l153
+				l154:
+					position, tokenIndex, depth = position153, tokenIndex153, depth153
 					if !_rules[ruleSimpleMerge]() {
-						goto l161
+						goto l151
 					}
 				}
-			l163:
+			l153:
 				depth--
-				add(ruleMerge, position162)
+				add(ruleMerge, position152)
 			}
 			return true
-		l161:
-			position, tokenIndex, depth = position161, tokenIndex161, depth161
+		l151:
+			position, tokenIndex, depth = position151, tokenIndex151, depth151
 			return false
 		},
 		/* 38 RefMerge <- <('m' 'e' 'r' 'g' 'e' !(req_ws Required) (req_ws (Replace / On))? req_ws Reference)> */
 		func() bool {
-			position165, tokenIndex165, depth165 := position, tokenIndex, depth
+			position155, tokenIndex155, depth155 := position, tokenIndex, depth
 			{
-				position166 := position
+				position156 := position
 				depth++
 				if buffer[position] != rune('m') {
-					goto l165
+					goto l155
 				}
 				position++
 				if buffer[position] != rune('e') {
-					goto l165
+					goto l155
 				}
 				position++
 				if buffer[position] != rune('r') {
-					goto l165
+					goto l155
 				}
 				position++
 				if buffer[position] != rune('g') {
-					goto l165
+					goto l155
 				}
 				position++
 				if buffer[position] != rune('e') {
-					goto l165
+					goto l155
 				}
 				position++
 				{
-					position167, tokenIndex167, depth167 := position, tokenIndex, depth
+					position157, tokenIndex157, depth157 := position, tokenIndex, depth
 					if !_rules[rulereq_ws]() {
-						goto l167
+						goto l157
 					}
 					if !_rules[ruleRequired]() {
-						goto l167
+						goto l157
 					}
-					goto l165
-				l167:
-					position, tokenIndex, depth = position167, tokenIndex167, depth167
+					goto l155
+				l157:
+					position, tokenIndex, depth = position157, tokenIndex157, depth157
 				}
 				{
-					position168, tokenIndex168, depth168 := position, tokenIndex, depth
+					position158, tokenIndex158, depth158 := position, tokenIndex, depth
 					if !_rules[rulereq_ws]() {
-						goto l168
+						goto l158
 					}
 					{
-						position170, tokenIndex170, depth170 := position, tokenIndex, depth
+						position160, tokenIndex160, depth160 := position, tokenIndex, depth
 						if !_rules[ruleReplace]() {
-							goto l171
+							goto l161
 						}
-						goto l170
-					l171:
-						position, tokenIndex, depth = position170, tokenIndex170, depth170
+						goto l160
+					l161:
+						position, tokenIndex, depth = position160, tokenIndex160, depth160
 						if !_rules[ruleOn]() {
-							goto l168
+							goto l158
 						}
 					}
-				l170:
-					goto l169
-				l168:
-					position, tokenIndex, depth = position168, tokenIndex168, depth168
+				l160:
+					goto l159
+				l158:
+					position, tokenIndex, depth = position158, tokenIndex158, depth158
 				}
-			l169:
+			l159:
 				if !_rules[rulereq_ws]() {
-					goto l165
+					goto l155
 				}
 				if !_rules[ruleReference]() {
-					goto l165
+					goto l155
 				}
 				depth--
-				add(ruleRefMerge, position166)
+				add(ruleRefMerge, position156)
 			}
 			return true
-		l165:
-			position, tokenIndex, depth = position165, tokenIndex165, depth165
+		l155:
+			position, tokenIndex, depth = position155, tokenIndex155, depth155
 			return false
 		},
 		/* 39 SimpleMerge <- <('m' 'e' 'r' 'g' 'e' (req_ws (Replace / Required / On))?)> */
 		func() bool {
-			position172, tokenIndex172, depth172 := position, tokenIndex, depth
+			position162, tokenIndex162, depth162 := position, tokenIndex, depth
 			{
-				position173 := position
+				position163 := position
 				depth++
 				if buffer[position] != rune('m') {
-					goto l172
+					goto l162
 				}
 				position++
 				if buffer[position] != rune('e') {
-					goto l172
+					goto l162
 				}
 				position++
 				if buffer[position] != rune('r') {
-					goto l172
+					goto l162
 				}
 				position++
 				if buffer[position] != rune('g') {
-					goto l172
+					goto l162
 				}
 				position++
 				if buffer[position] != rune('e') {
-					goto l172
+					goto l162
 				}
 				position++
 				{
-					position174, tokenIndex174, depth174 := position, tokenIndex, depth
+					position164, tokenIndex164, depth164 := position, tokenIndex, depth
 					if !_rules[rulereq_ws]() {
-						goto l174
+						goto l164
 					}
 					{
-						position176, tokenIndex176, depth176 := position, tokenIndex, depth
+						position166, tokenIndex166, depth166 := position, tokenIndex, depth
 						if !_rules[ruleReplace]() {
-							goto l177
+							goto l167
 						}
-						goto l176
-					l177:
-						position, tokenIndex, depth = position176, tokenIndex176, depth176
+						goto l166
+					l167:
+						position, tokenIndex, depth = position166, tokenIndex166, depth166
 						if !_rules[ruleRequired]() {
-							goto l178
+							goto l168
 						}
-						goto l176
-					l178:
-						position, tokenIndex, depth = position176, tokenIndex176, depth176
+						goto l166
+					l168:
+						position, tokenIndex, depth = position166, tokenIndex166, depth166
 						if !_rules[ruleOn]() {
-							goto l174
+							goto l164
 						}
 					}
-				l176:
-					goto l175
-				l174:
-					position, tokenIndex, depth = position174, tokenIndex174, depth174
+				l166:
+					goto l165
+				l164:
+					position, tokenIndex, depth = position164, tokenIndex164, depth164
 				}
-			l175:
+			l165:
 				depth--
-				add(ruleSimpleMerge, position173)
+				add(ruleSimpleMerge, position163)
 			}
 			return true
-		l172:
-			position, tokenIndex, depth = position172, tokenIndex172, depth172
+		l162:
+			position, tokenIndex, depth = position162, tokenIndex162, depth162
 			return false
 		},
 		/* 40 Replace <- <('r' 'e' 'p' 'l' 'a' 'c' 'e')> */
 		func() bool {
-			position179, tokenIndex179, depth179 := position, tokenIndex, depth
+			position169, tokenIndex169, depth169 := position, tokenIndex, depth
 			{
-				position180 := position
+				position170 := position
 				depth++
 				if buffer[position] != rune('r') {
-					goto l179
+					goto l169
 				}
 				position++
 				if buffer[position] != rune('e') {
-					goto l179
+					goto l169
 				}
 				position++
 				if buffer[position] != rune('p') {
-					goto l179
+					goto l169
 				}
 				position++
 				if buffer[position] != rune('l') {
-					goto l179
+					goto l169
 				}
 				position++
 				if buffer[position] != rune('a') {
-					goto l179
+					goto l169
 				}
 				position++
 				if buffer[position] != rune('c') {
-					goto l179
+					goto l169
 				}
 				position++
 				if buffer[position] != rune('e') {
-					goto l179
+					goto l169
 				}
 				position++
 				depth--
-				add(ruleReplace, position180)
+				add(ruleReplace, position170)
 			}
 			return true
-		l179:
-			position, tokenIndex, depth = position179, tokenIndex179, depth179
+		l169:
+			position, tokenIndex, depth = position169, tokenIndex169, depth169
 			return false
 		},
 		/* 41 Required <- <('r' 'e' 'q' 'u' 'i' 'r' 'e' 'd')> */
+		func() bool {
+			position171, tokenIndex171, depth171 := position, tokenIndex, depth
+			{
+				position172 := position
+				depth++
+				if buffer[position] != rune('r') {
+					goto l171
+				}
+				position++
+				if buffer[position] != rune('e') {
+					goto l171
+				}
+				position++
+				if buffer[position] != rune('q') {
+					goto l171
+				}
+				position++
+				if buffer[position] != rune('u') {
+					goto l171
+				}
+				position++
+				if buffer[position] != rune('i') {
+					goto l171
+				}
+				position++
+				if buffer[position] != rune('r') {
+					goto l171
+				}
+				position++
+				if buffer[position] != rune('e') {
+					goto l171
+				}
+				position++
+				if buffer[position] != rune('d') {
+					goto l171
+				}
+				position++
+				depth--
+				add(ruleRequired, position172)
+			}
+			return true
+		l171:
+			position, tokenIndex, depth = position171, tokenIndex171, depth171
+			return false
+		},
+		/* 42 On <- <('o' 'n' req_ws Name)> */
+		func() bool {
+			position173, tokenIndex173, depth173 := position, tokenIndex, depth
+			{
+				position174 := position
+				depth++
+				if buffer[position] != rune('o') {
+					goto l173
+				}
+				position++
+				if buffer[position] != rune('n') {
+					goto l173
+				}
+				position++
+				if !_rules[rulereq_ws]() {
+					goto l173
+				}
+				if !_rules[ruleName]() {
+					goto l173
+				}
+				depth--
+				add(ruleOn, position174)
+			}
+			return true
+		l173:
+			position, tokenIndex, depth = position173, tokenIndex173, depth173
+			return false
+		},
+		/* 43 Auto <- <('a' 'u' 't' 'o')> */
+		func() bool {
+			position175, tokenIndex175, depth175 := position, tokenIndex, depth
+			{
+				position176 := position
+				depth++
+				if buffer[position] != rune('a') {
+					goto l175
+				}
+				position++
+				if buffer[position] != rune('u') {
+					goto l175
+				}
+				position++
+				if buffer[position] != rune('t') {
+					goto l175
+				}
+				position++
+				if buffer[position] != rune('o') {
+					goto l175
+				}
+				position++
+				depth--
+				add(ruleAuto, position176)
+			}
+			return true
+		l175:
+			position, tokenIndex, depth = position175, tokenIndex175, depth175
+			return false
+		},
+		/* 44 Mapping <- <('m' 'a' 'p' '[' Level7 (LambdaExpr / ('|' Expression)) ']')> */
+		func() bool {
+			position177, tokenIndex177, depth177 := position, tokenIndex, depth
+			{
+				position178 := position
+				depth++
+				if buffer[position] != rune('m') {
+					goto l177
+				}
+				position++
+				if buffer[position] != rune('a') {
+					goto l177
+				}
+				position++
+				if buffer[position] != rune('p') {
+					goto l177
+				}
+				position++
+				if buffer[position] != rune('[') {
+					goto l177
+				}
+				position++
+				if !_rules[ruleLevel7]() {
+					goto l177
+				}
+				{
+					position179, tokenIndex179, depth179 := position, tokenIndex, depth
+					if !_rules[ruleLambdaExpr]() {
+						goto l180
+					}
+					goto l179
+				l180:
+					position, tokenIndex, depth = position179, tokenIndex179, depth179
+					if buffer[position] != rune('|') {
+						goto l177
+					}
+					position++
+					if !_rules[ruleExpression]() {
+						goto l177
+					}
+				}
+			l179:
+				if buffer[position] != rune(']') {
+					goto l177
+				}
+				position++
+				depth--
+				add(ruleMapping, position178)
+			}
+			return true
+		l177:
+			position, tokenIndex, depth = position177, tokenIndex177, depth177
+			return false
+		},
+		/* 45 Lambda <- <('l' 'a' 'm' 'b' 'd' 'a' (LambdaRef / LambdaExpr))> */
 		func() bool {
 			position181, tokenIndex181, depth181 := position, tokenIndex, depth
 			{
 				position182 := position
 				depth++
-				if buffer[position] != rune('r') {
+				if buffer[position] != rune('l') {
 					goto l181
 				}
 				position++
-				if buffer[position] != rune('e') {
+				if buffer[position] != rune('a') {
 					goto l181
 				}
 				position++
-				if buffer[position] != rune('q') {
+				if buffer[position] != rune('m') {
 					goto l181
 				}
 				position++
-				if buffer[position] != rune('u') {
-					goto l181
-				}
-				position++
-				if buffer[position] != rune('i') {
-					goto l181
-				}
-				position++
-				if buffer[position] != rune('r') {
-					goto l181
-				}
-				position++
-				if buffer[position] != rune('e') {
+				if buffer[position] != rune('b') {
 					goto l181
 				}
 				position++
@@ -2227,714 +2303,647 @@ func (p *DynamlGrammar) Init() {
 					goto l181
 				}
 				position++
+				if buffer[position] != rune('a') {
+					goto l181
+				}
+				position++
+				{
+					position183, tokenIndex183, depth183 := position, tokenIndex, depth
+					if !_rules[ruleLambdaRef]() {
+						goto l184
+					}
+					goto l183
+				l184:
+					position, tokenIndex, depth = position183, tokenIndex183, depth183
+					if !_rules[ruleLambdaExpr]() {
+						goto l181
+					}
+				}
+			l183:
 				depth--
-				add(ruleRequired, position182)
+				add(ruleLambda, position182)
 			}
 			return true
 		l181:
 			position, tokenIndex, depth = position181, tokenIndex181, depth181
 			return false
 		},
-		/* 42 On <- <('o' 'n' req_ws Name)> */
-		func() bool {
-			position183, tokenIndex183, depth183 := position, tokenIndex, depth
-			{
-				position184 := position
-				depth++
-				if buffer[position] != rune('o') {
-					goto l183
-				}
-				position++
-				if buffer[position] != rune('n') {
-					goto l183
-				}
-				position++
-				if !_rules[rulereq_ws]() {
-					goto l183
-				}
-				if !_rules[ruleName]() {
-					goto l183
-				}
-				depth--
-				add(ruleOn, position184)
-			}
-			return true
-		l183:
-			position, tokenIndex, depth = position183, tokenIndex183, depth183
-			return false
-		},
-		/* 43 Auto <- <('a' 'u' 't' 'o')> */
+		/* 46 LambdaRef <- <(req_ws Expression)> */
 		func() bool {
 			position185, tokenIndex185, depth185 := position, tokenIndex, depth
 			{
 				position186 := position
 				depth++
-				if buffer[position] != rune('a') {
+				if !_rules[rulereq_ws]() {
 					goto l185
 				}
-				position++
-				if buffer[position] != rune('u') {
+				if !_rules[ruleExpression]() {
 					goto l185
 				}
-				position++
-				if buffer[position] != rune('t') {
-					goto l185
-				}
-				position++
-				if buffer[position] != rune('o') {
-					goto l185
-				}
-				position++
 				depth--
-				add(ruleAuto, position186)
+				add(ruleLambdaRef, position186)
 			}
 			return true
 		l185:
 			position, tokenIndex, depth = position185, tokenIndex185, depth185
 			return false
 		},
-		/* 44 Mapping <- <('m' 'a' 'p' '[' Level7 (LambdaExpr / ('|' Expression)) ']')> */
+		/* 47 LambdaExpr <- <(ws '|' ws Name NextName* ws '|' ws ('-' '>') Expression)> */
 		func() bool {
 			position187, tokenIndex187, depth187 := position, tokenIndex, depth
 			{
 				position188 := position
 				depth++
-				if buffer[position] != rune('m') {
+				if !_rules[rulews]() {
+					goto l187
+				}
+				if buffer[position] != rune('|') {
 					goto l187
 				}
 				position++
-				if buffer[position] != rune('a') {
+				if !_rules[rulews]() {
 					goto l187
 				}
-				position++
-				if buffer[position] != rune('p') {
+				if !_rules[ruleName]() {
 					goto l187
 				}
-				position++
-				if buffer[position] != rune('[') {
-					goto l187
-				}
-				position++
-				if !_rules[ruleLevel7]() {
-					goto l187
-				}
+			l189:
 				{
-					position189, tokenIndex189, depth189 := position, tokenIndex, depth
-					if !_rules[ruleLambdaExpr]() {
+					position190, tokenIndex190, depth190 := position, tokenIndex, depth
+					if !_rules[ruleNextName]() {
 						goto l190
 					}
 					goto l189
 				l190:
-					position, tokenIndex, depth = position189, tokenIndex189, depth189
-					if buffer[position] != rune('|') {
-						goto l187
-					}
-					position++
-					if !_rules[ruleExpression]() {
-						goto l187
-					}
+					position, tokenIndex, depth = position190, tokenIndex190, depth190
 				}
-			l189:
-				if buffer[position] != rune(']') {
+				if !_rules[rulews]() {
+					goto l187
+				}
+				if buffer[position] != rune('|') {
 					goto l187
 				}
 				position++
+				if !_rules[rulews]() {
+					goto l187
+				}
+				if buffer[position] != rune('-') {
+					goto l187
+				}
+				position++
+				if buffer[position] != rune('>') {
+					goto l187
+				}
+				position++
+				if !_rules[ruleExpression]() {
+					goto l187
+				}
 				depth--
-				add(ruleMapping, position188)
+				add(ruleLambdaExpr, position188)
 			}
 			return true
 		l187:
 			position, tokenIndex, depth = position187, tokenIndex187, depth187
 			return false
 		},
-		/* 45 Lambda <- <('l' 'a' 'm' 'b' 'd' 'a' (LambdaRef / LambdaExpr))> */
+		/* 48 NextName <- <(ws ',' ws Name)> */
 		func() bool {
 			position191, tokenIndex191, depth191 := position, tokenIndex, depth
 			{
 				position192 := position
 				depth++
-				if buffer[position] != rune('l') {
+				if !_rules[rulews]() {
+					goto l191
+				}
+				if buffer[position] != rune(',') {
 					goto l191
 				}
 				position++
-				if buffer[position] != rune('a') {
+				if !_rules[rulews]() {
 					goto l191
 				}
-				position++
-				if buffer[position] != rune('m') {
+				if !_rules[ruleName]() {
 					goto l191
 				}
-				position++
-				if buffer[position] != rune('b') {
-					goto l191
-				}
-				position++
-				if buffer[position] != rune('d') {
-					goto l191
-				}
-				position++
-				if buffer[position] != rune('a') {
-					goto l191
-				}
-				position++
-				{
-					position193, tokenIndex193, depth193 := position, tokenIndex, depth
-					if !_rules[ruleLambdaRef]() {
-						goto l194
-					}
-					goto l193
-				l194:
-					position, tokenIndex, depth = position193, tokenIndex193, depth193
-					if !_rules[ruleLambdaExpr]() {
-						goto l191
-					}
-				}
-			l193:
 				depth--
-				add(ruleLambda, position192)
+				add(ruleNextName, position192)
 			}
 			return true
 		l191:
 			position, tokenIndex, depth = position191, tokenIndex191, depth191
 			return false
 		},
-		/* 46 LambdaRef <- <(req_ws Expression)> */
+		/* 49 Name <- <([a-z] / [A-Z] / [0-9] / '_')+> */
 		func() bool {
-			position195, tokenIndex195, depth195 := position, tokenIndex, depth
+			position193, tokenIndex193, depth193 := position, tokenIndex, depth
 			{
-				position196 := position
+				position194 := position
 				depth++
-				if !_rules[rulereq_ws]() {
-					goto l195
-				}
-				if !_rules[ruleExpression]() {
-					goto l195
-				}
-				depth--
-				add(ruleLambdaRef, position196)
-			}
-			return true
-		l195:
-			position, tokenIndex, depth = position195, tokenIndex195, depth195
-			return false
-		},
-		/* 47 LambdaExpr <- <(ws '|' ws Name NextName* ws '|' ws ('-' '>') Expression)> */
-		func() bool {
-			position197, tokenIndex197, depth197 := position, tokenIndex, depth
-			{
-				position198 := position
-				depth++
-				if !_rules[rulews]() {
-					goto l197
-				}
-				if buffer[position] != rune('|') {
-					goto l197
-				}
-				position++
-				if !_rules[rulews]() {
-					goto l197
-				}
-				if !_rules[ruleName]() {
-					goto l197
-				}
-			l199:
 				{
-					position200, tokenIndex200, depth200 := position, tokenIndex, depth
-					if !_rules[ruleNextName]() {
+					position197, tokenIndex197, depth197 := position, tokenIndex, depth
+					if c := buffer[position]; c < rune('a') || c > rune('z') {
+						goto l198
+					}
+					position++
+					goto l197
+				l198:
+					position, tokenIndex, depth = position197, tokenIndex197, depth197
+					if c := buffer[position]; c < rune('A') || c > rune('Z') {
+						goto l199
+					}
+					position++
+					goto l197
+				l199:
+					position, tokenIndex, depth = position197, tokenIndex197, depth197
+					if c := buffer[position]; c < rune('0') || c > rune('9') {
 						goto l200
 					}
-					goto l199
+					position++
+					goto l197
 				l200:
-					position, tokenIndex, depth = position200, tokenIndex200, depth200
-				}
-				if !_rules[rulews]() {
-					goto l197
-				}
-				if buffer[position] != rune('|') {
-					goto l197
-				}
-				position++
-				if !_rules[rulews]() {
-					goto l197
-				}
-				if buffer[position] != rune('-') {
-					goto l197
-				}
-				position++
-				if buffer[position] != rune('>') {
-					goto l197
-				}
-				position++
-				if !_rules[ruleExpression]() {
-					goto l197
-				}
-				depth--
-				add(ruleLambdaExpr, position198)
-			}
-			return true
-		l197:
-			position, tokenIndex, depth = position197, tokenIndex197, depth197
-			return false
-		},
-		/* 48 NextName <- <(ws ',' ws Name)> */
-		func() bool {
-			position201, tokenIndex201, depth201 := position, tokenIndex, depth
-			{
-				position202 := position
-				depth++
-				if !_rules[rulews]() {
-					goto l201
-				}
-				if buffer[position] != rune(',') {
-					goto l201
-				}
-				position++
-				if !_rules[rulews]() {
-					goto l201
-				}
-				if !_rules[ruleName]() {
-					goto l201
-				}
-				depth--
-				add(ruleNextName, position202)
-			}
-			return true
-		l201:
-			position, tokenIndex, depth = position201, tokenIndex201, depth201
-			return false
-		},
-		/* 49 Reference <- <('.'? Key ('.' (Key / Index))*)> */
-		func() bool {
-			position203, tokenIndex203, depth203 := position, tokenIndex, depth
-			{
-				position204 := position
-				depth++
-				{
-					position205, tokenIndex205, depth205 := position, tokenIndex, depth
-					if buffer[position] != rune('.') {
-						goto l205
+					position, tokenIndex, depth = position197, tokenIndex197, depth197
+					if buffer[position] != rune('_') {
+						goto l193
 					}
 					position++
-					goto l206
-				l205:
-					position, tokenIndex, depth = position205, tokenIndex205, depth205
 				}
-			l206:
-				if !_rules[ruleKey]() {
-					goto l203
-				}
-			l207:
+			l197:
+			l195:
 				{
-					position208, tokenIndex208, depth208 := position, tokenIndex, depth
+					position196, tokenIndex196, depth196 := position, tokenIndex, depth
+					{
+						position201, tokenIndex201, depth201 := position, tokenIndex, depth
+						if c := buffer[position]; c < rune('a') || c > rune('z') {
+							goto l202
+						}
+						position++
+						goto l201
+					l202:
+						position, tokenIndex, depth = position201, tokenIndex201, depth201
+						if c := buffer[position]; c < rune('A') || c > rune('Z') {
+							goto l203
+						}
+						position++
+						goto l201
+					l203:
+						position, tokenIndex, depth = position201, tokenIndex201, depth201
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l204
+						}
+						position++
+						goto l201
+					l204:
+						position, tokenIndex, depth = position201, tokenIndex201, depth201
+						if buffer[position] != rune('_') {
+							goto l196
+						}
+						position++
+					}
+				l201:
+					goto l195
+				l196:
+					position, tokenIndex, depth = position196, tokenIndex196, depth196
+				}
+				depth--
+				add(ruleName, position194)
+			}
+			return true
+		l193:
+			position, tokenIndex, depth = position193, tokenIndex193, depth193
+			return false
+		},
+		/* 50 Reference <- <('.'? Key ('.' (Key / Index))*)> */
+		func() bool {
+			position205, tokenIndex205, depth205 := position, tokenIndex, depth
+			{
+				position206 := position
+				depth++
+				{
+					position207, tokenIndex207, depth207 := position, tokenIndex, depth
 					if buffer[position] != rune('.') {
-						goto l208
+						goto l207
+					}
+					position++
+					goto l208
+				l207:
+					position, tokenIndex, depth = position207, tokenIndex207, depth207
+				}
+			l208:
+				if !_rules[ruleKey]() {
+					goto l205
+				}
+			l209:
+				{
+					position210, tokenIndex210, depth210 := position, tokenIndex, depth
+					if buffer[position] != rune('.') {
+						goto l210
 					}
 					position++
 					{
-						position209, tokenIndex209, depth209 := position, tokenIndex, depth
+						position211, tokenIndex211, depth211 := position, tokenIndex, depth
 						if !_rules[ruleKey]() {
+							goto l212
+						}
+						goto l211
+					l212:
+						position, tokenIndex, depth = position211, tokenIndex211, depth211
+						if !_rules[ruleIndex]() {
 							goto l210
 						}
-						goto l209
-					l210:
-						position, tokenIndex, depth = position209, tokenIndex209, depth209
-						if !_rules[ruleIndex]() {
-							goto l208
-						}
 					}
-				l209:
-					goto l207
-				l208:
-					position, tokenIndex, depth = position208, tokenIndex208, depth208
+				l211:
+					goto l209
+				l210:
+					position, tokenIndex, depth = position210, tokenIndex210, depth210
 				}
 				depth--
-				add(ruleReference, position204)
+				add(ruleReference, position206)
 			}
 			return true
-		l203:
-			position, tokenIndex, depth = position203, tokenIndex203, depth203
+		l205:
+			position, tokenIndex, depth = position205, tokenIndex205, depth205
 			return false
 		},
-		/* 50 FollowUpRef <- <((Key / Index) ('.' (Key / Index))*)> */
+		/* 51 FollowUpRef <- <((Key / Index) ('.' (Key / Index))*)> */
 		func() bool {
-			position211, tokenIndex211, depth211 := position, tokenIndex, depth
+			position213, tokenIndex213, depth213 := position, tokenIndex, depth
 			{
-				position212 := position
+				position214 := position
 				depth++
 				{
-					position213, tokenIndex213, depth213 := position, tokenIndex, depth
+					position215, tokenIndex215, depth215 := position, tokenIndex, depth
 					if !_rules[ruleKey]() {
-						goto l214
+						goto l216
 					}
-					goto l213
-				l214:
-					position, tokenIndex, depth = position213, tokenIndex213, depth213
+					goto l215
+				l216:
+					position, tokenIndex, depth = position215, tokenIndex215, depth215
 					if !_rules[ruleIndex]() {
-						goto l211
+						goto l213
 					}
 				}
-			l213:
 			l215:
+			l217:
 				{
-					position216, tokenIndex216, depth216 := position, tokenIndex, depth
+					position218, tokenIndex218, depth218 := position, tokenIndex, depth
 					if buffer[position] != rune('.') {
-						goto l216
+						goto l218
 					}
 					position++
 					{
-						position217, tokenIndex217, depth217 := position, tokenIndex, depth
+						position219, tokenIndex219, depth219 := position, tokenIndex, depth
 						if !_rules[ruleKey]() {
+							goto l220
+						}
+						goto l219
+					l220:
+						position, tokenIndex, depth = position219, tokenIndex219, depth219
+						if !_rules[ruleIndex]() {
 							goto l218
 						}
-						goto l217
-					l218:
-						position, tokenIndex, depth = position217, tokenIndex217, depth217
-						if !_rules[ruleIndex]() {
-							goto l216
-						}
 					}
-				l217:
-					goto l215
-				l216:
-					position, tokenIndex, depth = position216, tokenIndex216, depth216
+				l219:
+					goto l217
+				l218:
+					position, tokenIndex, depth = position218, tokenIndex218, depth218
 				}
 				depth--
-				add(ruleFollowUpRef, position212)
+				add(ruleFollowUpRef, position214)
 			}
 			return true
-		l211:
-			position, tokenIndex, depth = position211, tokenIndex211, depth211
+		l213:
+			position, tokenIndex, depth = position213, tokenIndex213, depth213
 			return false
 		},
-		/* 51 Key <- <(([a-z] / [A-Z] / [0-9] / '_') ([a-z] / [A-Z] / [0-9] / '_' / '-')* (':' ([a-z] / [A-Z] / [0-9] / '_') ([a-z] / [A-Z] / [0-9] / '_' / '-')*)?)> */
+		/* 52 Key <- <(([a-z] / [A-Z] / [0-9] / '_') ([a-z] / [A-Z] / [0-9] / '_' / '-')* (':' ([a-z] / [A-Z] / [0-9] / '_') ([a-z] / [A-Z] / [0-9] / '_' / '-')*)?)> */
 		func() bool {
-			position219, tokenIndex219, depth219 := position, tokenIndex, depth
+			position221, tokenIndex221, depth221 := position, tokenIndex, depth
 			{
-				position220 := position
+				position222 := position
 				depth++
 				{
-					position221, tokenIndex221, depth221 := position, tokenIndex, depth
+					position223, tokenIndex223, depth223 := position, tokenIndex, depth
 					if c := buffer[position]; c < rune('a') || c > rune('z') {
-						goto l222
-					}
-					position++
-					goto l221
-				l222:
-					position, tokenIndex, depth = position221, tokenIndex221, depth221
-					if c := buffer[position]; c < rune('A') || c > rune('Z') {
-						goto l223
-					}
-					position++
-					goto l221
-				l223:
-					position, tokenIndex, depth = position221, tokenIndex221, depth221
-					if c := buffer[position]; c < rune('0') || c > rune('9') {
 						goto l224
 					}
 					position++
-					goto l221
+					goto l223
 				l224:
-					position, tokenIndex, depth = position221, tokenIndex221, depth221
+					position, tokenIndex, depth = position223, tokenIndex223, depth223
+					if c := buffer[position]; c < rune('A') || c > rune('Z') {
+						goto l225
+					}
+					position++
+					goto l223
+				l225:
+					position, tokenIndex, depth = position223, tokenIndex223, depth223
+					if c := buffer[position]; c < rune('0') || c > rune('9') {
+						goto l226
+					}
+					position++
+					goto l223
+				l226:
+					position, tokenIndex, depth = position223, tokenIndex223, depth223
 					if buffer[position] != rune('_') {
-						goto l219
+						goto l221
 					}
 					position++
 				}
-			l221:
-			l225:
+			l223:
+			l227:
 				{
-					position226, tokenIndex226, depth226 := position, tokenIndex, depth
+					position228, tokenIndex228, depth228 := position, tokenIndex, depth
 					{
-						position227, tokenIndex227, depth227 := position, tokenIndex, depth
+						position229, tokenIndex229, depth229 := position, tokenIndex, depth
 						if c := buffer[position]; c < rune('a') || c > rune('z') {
-							goto l228
-						}
-						position++
-						goto l227
-					l228:
-						position, tokenIndex, depth = position227, tokenIndex227, depth227
-						if c := buffer[position]; c < rune('A') || c > rune('Z') {
-							goto l229
-						}
-						position++
-						goto l227
-					l229:
-						position, tokenIndex, depth = position227, tokenIndex227, depth227
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
 							goto l230
 						}
 						position++
-						goto l227
+						goto l229
 					l230:
-						position, tokenIndex, depth = position227, tokenIndex227, depth227
-						if buffer[position] != rune('_') {
+						position, tokenIndex, depth = position229, tokenIndex229, depth229
+						if c := buffer[position]; c < rune('A') || c > rune('Z') {
 							goto l231
 						}
 						position++
-						goto l227
+						goto l229
 					l231:
-						position, tokenIndex, depth = position227, tokenIndex227, depth227
-						if buffer[position] != rune('-') {
-							goto l226
-						}
-						position++
-					}
-				l227:
-					goto l225
-				l226:
-					position, tokenIndex, depth = position226, tokenIndex226, depth226
-				}
-				{
-					position232, tokenIndex232, depth232 := position, tokenIndex, depth
-					if buffer[position] != rune(':') {
-						goto l232
-					}
-					position++
-					{
-						position234, tokenIndex234, depth234 := position, tokenIndex, depth
-						if c := buffer[position]; c < rune('a') || c > rune('z') {
-							goto l235
-						}
-						position++
-						goto l234
-					l235:
-						position, tokenIndex, depth = position234, tokenIndex234, depth234
-						if c := buffer[position]; c < rune('A') || c > rune('Z') {
-							goto l236
-						}
-						position++
-						goto l234
-					l236:
-						position, tokenIndex, depth = position234, tokenIndex234, depth234
+						position, tokenIndex, depth = position229, tokenIndex229, depth229
 						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l237
-						}
-						position++
-						goto l234
-					l237:
-						position, tokenIndex, depth = position234, tokenIndex234, depth234
-						if buffer[position] != rune('_') {
 							goto l232
 						}
 						position++
+						goto l229
+					l232:
+						position, tokenIndex, depth = position229, tokenIndex229, depth229
+						if buffer[position] != rune('_') {
+							goto l233
+						}
+						position++
+						goto l229
+					l233:
+						position, tokenIndex, depth = position229, tokenIndex229, depth229
+						if buffer[position] != rune('-') {
+							goto l228
+						}
+						position++
 					}
-				l234:
-				l238:
+				l229:
+					goto l227
+				l228:
+					position, tokenIndex, depth = position228, tokenIndex228, depth228
+				}
+				{
+					position234, tokenIndex234, depth234 := position, tokenIndex, depth
+					if buffer[position] != rune(':') {
+						goto l234
+					}
+					position++
 					{
-						position239, tokenIndex239, depth239 := position, tokenIndex, depth
+						position236, tokenIndex236, depth236 := position, tokenIndex, depth
+						if c := buffer[position]; c < rune('a') || c > rune('z') {
+							goto l237
+						}
+						position++
+						goto l236
+					l237:
+						position, tokenIndex, depth = position236, tokenIndex236, depth236
+						if c := buffer[position]; c < rune('A') || c > rune('Z') {
+							goto l238
+						}
+						position++
+						goto l236
+					l238:
+						position, tokenIndex, depth = position236, tokenIndex236, depth236
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l239
+						}
+						position++
+						goto l236
+					l239:
+						position, tokenIndex, depth = position236, tokenIndex236, depth236
+						if buffer[position] != rune('_') {
+							goto l234
+						}
+						position++
+					}
+				l236:
+				l240:
+					{
+						position241, tokenIndex241, depth241 := position, tokenIndex, depth
 						{
-							position240, tokenIndex240, depth240 := position, tokenIndex, depth
+							position242, tokenIndex242, depth242 := position, tokenIndex, depth
 							if c := buffer[position]; c < rune('a') || c > rune('z') {
-								goto l241
-							}
-							position++
-							goto l240
-						l241:
-							position, tokenIndex, depth = position240, tokenIndex240, depth240
-							if c := buffer[position]; c < rune('A') || c > rune('Z') {
-								goto l242
-							}
-							position++
-							goto l240
-						l242:
-							position, tokenIndex, depth = position240, tokenIndex240, depth240
-							if c := buffer[position]; c < rune('0') || c > rune('9') {
 								goto l243
 							}
 							position++
-							goto l240
+							goto l242
 						l243:
-							position, tokenIndex, depth = position240, tokenIndex240, depth240
-							if buffer[position] != rune('_') {
+							position, tokenIndex, depth = position242, tokenIndex242, depth242
+							if c := buffer[position]; c < rune('A') || c > rune('Z') {
 								goto l244
 							}
 							position++
-							goto l240
+							goto l242
 						l244:
-							position, tokenIndex, depth = position240, tokenIndex240, depth240
+							position, tokenIndex, depth = position242, tokenIndex242, depth242
+							if c := buffer[position]; c < rune('0') || c > rune('9') {
+								goto l245
+							}
+							position++
+							goto l242
+						l245:
+							position, tokenIndex, depth = position242, tokenIndex242, depth242
+							if buffer[position] != rune('_') {
+								goto l246
+							}
+							position++
+							goto l242
+						l246:
+							position, tokenIndex, depth = position242, tokenIndex242, depth242
 							if buffer[position] != rune('-') {
-								goto l239
+								goto l241
 							}
 							position++
 						}
-					l240:
-						goto l238
-					l239:
-						position, tokenIndex, depth = position239, tokenIndex239, depth239
+					l242:
+						goto l240
+					l241:
+						position, tokenIndex, depth = position241, tokenIndex241, depth241
 					}
-					goto l233
-				l232:
-					position, tokenIndex, depth = position232, tokenIndex232, depth232
+					goto l235
+				l234:
+					position, tokenIndex, depth = position234, tokenIndex234, depth234
 				}
-			l233:
+			l235:
 				depth--
-				add(ruleKey, position220)
+				add(ruleKey, position222)
 			}
 			return true
-		l219:
-			position, tokenIndex, depth = position219, tokenIndex219, depth219
+		l221:
+			position, tokenIndex, depth = position221, tokenIndex221, depth221
 			return false
 		},
-		/* 52 Index <- <('[' [0-9]+ ']')> */
+		/* 53 Index <- <('[' [0-9]+ ']')> */
 		func() bool {
-			position245, tokenIndex245, depth245 := position, tokenIndex, depth
+			position247, tokenIndex247, depth247 := position, tokenIndex, depth
 			{
-				position246 := position
+				position248 := position
 				depth++
 				if buffer[position] != rune('[') {
-					goto l245
+					goto l247
 				}
 				position++
 				if c := buffer[position]; c < rune('0') || c > rune('9') {
-					goto l245
+					goto l247
 				}
 				position++
-			l247:
+			l249:
 				{
-					position248, tokenIndex248, depth248 := position, tokenIndex, depth
+					position250, tokenIndex250, depth250 := position, tokenIndex, depth
 					if c := buffer[position]; c < rune('0') || c > rune('9') {
-						goto l248
+						goto l250
 					}
 					position++
-					goto l247
-				l248:
-					position, tokenIndex, depth = position248, tokenIndex248, depth248
+					goto l249
+				l250:
+					position, tokenIndex, depth = position250, tokenIndex250, depth250
 				}
 				if buffer[position] != rune(']') {
-					goto l245
+					goto l247
 				}
 				position++
 				depth--
-				add(ruleIndex, position246)
+				add(ruleIndex, position248)
 			}
 			return true
-		l245:
-			position, tokenIndex, depth = position245, tokenIndex245, depth245
+		l247:
+			position, tokenIndex, depth = position247, tokenIndex247, depth247
 			return false
 		},
-		/* 53 ws <- <(' ' / '\t' / '\n' / '\r')*> */
+		/* 54 ws <- <(' ' / '\t' / '\n' / '\r')*> */
 		func() bool {
 			{
-				position250 := position
+				position252 := position
 				depth++
-			l251:
+			l253:
 				{
-					position252, tokenIndex252, depth252 := position, tokenIndex, depth
+					position254, tokenIndex254, depth254 := position, tokenIndex, depth
 					{
-						position253, tokenIndex253, depth253 := position, tokenIndex, depth
+						position255, tokenIndex255, depth255 := position, tokenIndex, depth
 						if buffer[position] != rune(' ') {
-							goto l254
-						}
-						position++
-						goto l253
-					l254:
-						position, tokenIndex, depth = position253, tokenIndex253, depth253
-						if buffer[position] != rune('\t') {
-							goto l255
-						}
-						position++
-						goto l253
-					l255:
-						position, tokenIndex, depth = position253, tokenIndex253, depth253
-						if buffer[position] != rune('\n') {
 							goto l256
 						}
 						position++
-						goto l253
+						goto l255
 					l256:
-						position, tokenIndex, depth = position253, tokenIndex253, depth253
+						position, tokenIndex, depth = position255, tokenIndex255, depth255
+						if buffer[position] != rune('\t') {
+							goto l257
+						}
+						position++
+						goto l255
+					l257:
+						position, tokenIndex, depth = position255, tokenIndex255, depth255
+						if buffer[position] != rune('\n') {
+							goto l258
+						}
+						position++
+						goto l255
+					l258:
+						position, tokenIndex, depth = position255, tokenIndex255, depth255
 						if buffer[position] != rune('\r') {
-							goto l252
+							goto l254
 						}
 						position++
 					}
-				l253:
-					goto l251
-				l252:
-					position, tokenIndex, depth = position252, tokenIndex252, depth252
+				l255:
+					goto l253
+				l254:
+					position, tokenIndex, depth = position254, tokenIndex254, depth254
 				}
 				depth--
-				add(rulews, position250)
+				add(rulews, position252)
 			}
 			return true
 		},
-		/* 54 req_ws <- <(' ' / '\t' / '\n' / '\r')+> */
+		/* 55 req_ws <- <(' ' / '\t' / '\n' / '\r')+> */
 		func() bool {
-			position257, tokenIndex257, depth257 := position, tokenIndex, depth
+			position259, tokenIndex259, depth259 := position, tokenIndex, depth
 			{
-				position258 := position
+				position260 := position
 				depth++
 				{
-					position261, tokenIndex261, depth261 := position, tokenIndex, depth
+					position263, tokenIndex263, depth263 := position, tokenIndex, depth
 					if buffer[position] != rune(' ') {
-						goto l262
-					}
-					position++
-					goto l261
-				l262:
-					position, tokenIndex, depth = position261, tokenIndex261, depth261
-					if buffer[position] != rune('\t') {
-						goto l263
-					}
-					position++
-					goto l261
-				l263:
-					position, tokenIndex, depth = position261, tokenIndex261, depth261
-					if buffer[position] != rune('\n') {
 						goto l264
 					}
 					position++
-					goto l261
+					goto l263
 				l264:
-					position, tokenIndex, depth = position261, tokenIndex261, depth261
+					position, tokenIndex, depth = position263, tokenIndex263, depth263
+					if buffer[position] != rune('\t') {
+						goto l265
+					}
+					position++
+					goto l263
+				l265:
+					position, tokenIndex, depth = position263, tokenIndex263, depth263
+					if buffer[position] != rune('\n') {
+						goto l266
+					}
+					position++
+					goto l263
+				l266:
+					position, tokenIndex, depth = position263, tokenIndex263, depth263
 					if buffer[position] != rune('\r') {
-						goto l257
+						goto l259
 					}
 					position++
 				}
+			l263:
 			l261:
-			l259:
 				{
-					position260, tokenIndex260, depth260 := position, tokenIndex, depth
+					position262, tokenIndex262, depth262 := position, tokenIndex, depth
 					{
-						position265, tokenIndex265, depth265 := position, tokenIndex, depth
+						position267, tokenIndex267, depth267 := position, tokenIndex, depth
 						if buffer[position] != rune(' ') {
-							goto l266
-						}
-						position++
-						goto l265
-					l266:
-						position, tokenIndex, depth = position265, tokenIndex265, depth265
-						if buffer[position] != rune('\t') {
-							goto l267
-						}
-						position++
-						goto l265
-					l267:
-						position, tokenIndex, depth = position265, tokenIndex265, depth265
-						if buffer[position] != rune('\n') {
 							goto l268
 						}
 						position++
-						goto l265
+						goto l267
 					l268:
-						position, tokenIndex, depth = position265, tokenIndex265, depth265
+						position, tokenIndex, depth = position267, tokenIndex267, depth267
+						if buffer[position] != rune('\t') {
+							goto l269
+						}
+						position++
+						goto l267
+					l269:
+						position, tokenIndex, depth = position267, tokenIndex267, depth267
+						if buffer[position] != rune('\n') {
+							goto l270
+						}
+						position++
+						goto l267
+					l270:
+						position, tokenIndex, depth = position267, tokenIndex267, depth267
 						if buffer[position] != rune('\r') {
-							goto l260
+							goto l262
 						}
 						position++
 					}
-				l265:
-					goto l259
-				l260:
-					position, tokenIndex, depth = position260, tokenIndex260, depth260
+				l267:
+					goto l261
+				l262:
+					position, tokenIndex, depth = position262, tokenIndex262, depth262
 				}
 				depth--
-				add(rulereq_ws, position258)
+				add(rulereq_ws, position260)
 			}
 			return true
-		l257:
-			position, tokenIndex, depth = position257, tokenIndex257, depth257
+		l259:
+			position, tokenIndex, depth = position259, tokenIndex259, depth259
 			return false
 		},
 	}

--- a/dynaml/dynaml.peg.go
+++ b/dynaml/dynaml.peg.go
@@ -663,7 +663,7 @@ func (p *DynamlGrammar) Init() {
 			position, tokenIndex, depth = position5, tokenIndex5, depth5
 			return false
 		},
-		/* 2 Expression <- <(ws Level7 ws)> */
+		/* 2 Expression <- <(ws (LambdaExpr / Level7) ws)> */
 		func() bool {
 			position7, tokenIndex7, depth7 := position, tokenIndex, depth
 			{
@@ -672,9 +672,19 @@ func (p *DynamlGrammar) Init() {
 				if !_rules[rulews]() {
 					goto l7
 				}
-				if !_rules[ruleLevel7]() {
-					goto l7
+				{
+					position9, tokenIndex9, depth9 := position, tokenIndex, depth
+					if !_rules[ruleLambdaExpr]() {
+						goto l10
+					}
+					goto l9
+				l10:
+					position, tokenIndex, depth = position9, tokenIndex9, depth9
+					if !_rules[ruleLevel7]() {
+						goto l7
+					}
 				}
+			l9:
 				if !_rules[rulews]() {
 					goto l7
 				}
@@ -688,243 +698,211 @@ func (p *DynamlGrammar) Init() {
 		},
 		/* 3 Level7 <- <(Level6 (req_ws Or)*)> */
 		func() bool {
-			position9, tokenIndex9, depth9 := position, tokenIndex, depth
+			position11, tokenIndex11, depth11 := position, tokenIndex, depth
 			{
-				position10 := position
+				position12 := position
 				depth++
 				if !_rules[ruleLevel6]() {
-					goto l9
+					goto l11
 				}
-			l11:
+			l13:
 				{
-					position12, tokenIndex12, depth12 := position, tokenIndex, depth
+					position14, tokenIndex14, depth14 := position, tokenIndex, depth
 					if !_rules[rulereq_ws]() {
-						goto l12
+						goto l14
 					}
 					if !_rules[ruleOr]() {
-						goto l12
+						goto l14
 					}
-					goto l11
-				l12:
-					position, tokenIndex, depth = position12, tokenIndex12, depth12
+					goto l13
+				l14:
+					position, tokenIndex, depth = position14, tokenIndex14, depth14
 				}
 				depth--
-				add(ruleLevel7, position10)
+				add(ruleLevel7, position12)
 			}
 			return true
-		l9:
-			position, tokenIndex, depth = position9, tokenIndex9, depth9
+		l11:
+			position, tokenIndex, depth = position11, tokenIndex11, depth11
 			return false
 		},
 		/* 4 Or <- <('|' '|' req_ws Level6)> */
-		func() bool {
-			position13, tokenIndex13, depth13 := position, tokenIndex, depth
-			{
-				position14 := position
-				depth++
-				if buffer[position] != rune('|') {
-					goto l13
-				}
-				position++
-				if buffer[position] != rune('|') {
-					goto l13
-				}
-				position++
-				if !_rules[rulereq_ws]() {
-					goto l13
-				}
-				if !_rules[ruleLevel6]() {
-					goto l13
-				}
-				depth--
-				add(ruleOr, position14)
-			}
-			return true
-		l13:
-			position, tokenIndex, depth = position13, tokenIndex13, depth13
-			return false
-		},
-		/* 5 Level6 <- <(Conditional / Level5)> */
 		func() bool {
 			position15, tokenIndex15, depth15 := position, tokenIndex, depth
 			{
 				position16 := position
 				depth++
-				{
-					position17, tokenIndex17, depth17 := position, tokenIndex, depth
-					if !_rules[ruleConditional]() {
-						goto l18
-					}
-					goto l17
-				l18:
-					position, tokenIndex, depth = position17, tokenIndex17, depth17
-					if !_rules[ruleLevel5]() {
-						goto l15
-					}
+				if buffer[position] != rune('|') {
+					goto l15
 				}
-			l17:
+				position++
+				if buffer[position] != rune('|') {
+					goto l15
+				}
+				position++
+				if !_rules[rulereq_ws]() {
+					goto l15
+				}
+				if !_rules[ruleLevel6]() {
+					goto l15
+				}
 				depth--
-				add(ruleLevel6, position16)
+				add(ruleOr, position16)
 			}
 			return true
 		l15:
 			position, tokenIndex, depth = position15, tokenIndex15, depth15
 			return false
 		},
-		/* 6 Conditional <- <(Level5 ws '?' Expression ':' Expression)> */
+		/* 5 Level6 <- <(Conditional / Level5)> */
 		func() bool {
-			position19, tokenIndex19, depth19 := position, tokenIndex, depth
+			position17, tokenIndex17, depth17 := position, tokenIndex, depth
 			{
-				position20 := position
+				position18 := position
 				depth++
-				if !_rules[ruleLevel5]() {
+				{
+					position19, tokenIndex19, depth19 := position, tokenIndex, depth
+					if !_rules[ruleConditional]() {
+						goto l20
+					}
 					goto l19
+				l20:
+					position, tokenIndex, depth = position19, tokenIndex19, depth19
+					if !_rules[ruleLevel5]() {
+						goto l17
+					}
 				}
-				if !_rules[rulews]() {
-					goto l19
-				}
-				if buffer[position] != rune('?') {
-					goto l19
-				}
-				position++
-				if !_rules[ruleExpression]() {
-					goto l19
-				}
-				if buffer[position] != rune(':') {
-					goto l19
-				}
-				position++
-				if !_rules[ruleExpression]() {
-					goto l19
-				}
+			l19:
 				depth--
-				add(ruleConditional, position20)
+				add(ruleLevel6, position18)
 			}
 			return true
-		l19:
-			position, tokenIndex, depth = position19, tokenIndex19, depth19
+		l17:
+			position, tokenIndex, depth = position17, tokenIndex17, depth17
 			return false
 		},
-		/* 7 Level5 <- <(Level4 Concatenation*)> */
+		/* 6 Conditional <- <(Level5 ws '?' Expression ':' Expression)> */
 		func() bool {
 			position21, tokenIndex21, depth21 := position, tokenIndex, depth
 			{
 				position22 := position
 				depth++
-				if !_rules[ruleLevel4]() {
+				if !_rules[ruleLevel5]() {
 					goto l21
 				}
-			l23:
-				{
-					position24, tokenIndex24, depth24 := position, tokenIndex, depth
-					if !_rules[ruleConcatenation]() {
-						goto l24
-					}
-					goto l23
-				l24:
-					position, tokenIndex, depth = position24, tokenIndex24, depth24
+				if !_rules[rulews]() {
+					goto l21
+				}
+				if buffer[position] != rune('?') {
+					goto l21
+				}
+				position++
+				if !_rules[ruleExpression]() {
+					goto l21
+				}
+				if buffer[position] != rune(':') {
+					goto l21
+				}
+				position++
+				if !_rules[ruleExpression]() {
+					goto l21
 				}
 				depth--
-				add(ruleLevel5, position22)
+				add(ruleConditional, position22)
 			}
 			return true
 		l21:
 			position, tokenIndex, depth = position21, tokenIndex21, depth21
 			return false
 		},
-		/* 8 Concatenation <- <(req_ws Level4)> */
+		/* 7 Level5 <- <(Level4 Concatenation*)> */
 		func() bool {
-			position25, tokenIndex25, depth25 := position, tokenIndex, depth
+			position23, tokenIndex23, depth23 := position, tokenIndex, depth
 			{
-				position26 := position
+				position24 := position
 				depth++
-				if !_rules[rulereq_ws]() {
-					goto l25
-				}
 				if !_rules[ruleLevel4]() {
+					goto l23
+				}
+			l25:
+				{
+					position26, tokenIndex26, depth26 := position, tokenIndex, depth
+					if !_rules[ruleConcatenation]() {
+						goto l26
+					}
 					goto l25
+				l26:
+					position, tokenIndex, depth = position26, tokenIndex26, depth26
 				}
 				depth--
-				add(ruleConcatenation, position26)
+				add(ruleLevel5, position24)
 			}
 			return true
-		l25:
-			position, tokenIndex, depth = position25, tokenIndex25, depth25
+		l23:
+			position, tokenIndex, depth = position23, tokenIndex23, depth23
 			return false
 		},
-		/* 9 Level4 <- <(Level3 (req_ws (LogOr / LogAnd))*)> */
+		/* 8 Concatenation <- <(req_ws Level4)> */
 		func() bool {
 			position27, tokenIndex27, depth27 := position, tokenIndex, depth
 			{
 				position28 := position
 				depth++
-				if !_rules[ruleLevel3]() {
+				if !_rules[rulereq_ws]() {
 					goto l27
 				}
-			l29:
-				{
-					position30, tokenIndex30, depth30 := position, tokenIndex, depth
-					if !_rules[rulereq_ws]() {
-						goto l30
-					}
-					{
-						position31, tokenIndex31, depth31 := position, tokenIndex, depth
-						if !_rules[ruleLogOr]() {
-							goto l32
-						}
-						goto l31
-					l32:
-						position, tokenIndex, depth = position31, tokenIndex31, depth31
-						if !_rules[ruleLogAnd]() {
-							goto l30
-						}
-					}
-				l31:
-					goto l29
-				l30:
-					position, tokenIndex, depth = position30, tokenIndex30, depth30
+				if !_rules[ruleLevel4]() {
+					goto l27
 				}
 				depth--
-				add(ruleLevel4, position28)
+				add(ruleConcatenation, position28)
 			}
 			return true
 		l27:
 			position, tokenIndex, depth = position27, tokenIndex27, depth27
 			return false
 		},
-		/* 10 LogOr <- <('-' 'o' 'r' req_ws Level3)> */
+		/* 9 Level4 <- <(Level3 (req_ws (LogOr / LogAnd))*)> */
 		func() bool {
-			position33, tokenIndex33, depth33 := position, tokenIndex, depth
+			position29, tokenIndex29, depth29 := position, tokenIndex, depth
 			{
-				position34 := position
+				position30 := position
 				depth++
-				if buffer[position] != rune('-') {
-					goto l33
-				}
-				position++
-				if buffer[position] != rune('o') {
-					goto l33
-				}
-				position++
-				if buffer[position] != rune('r') {
-					goto l33
-				}
-				position++
-				if !_rules[rulereq_ws]() {
-					goto l33
-				}
 				if !_rules[ruleLevel3]() {
-					goto l33
+					goto l29
+				}
+			l31:
+				{
+					position32, tokenIndex32, depth32 := position, tokenIndex, depth
+					if !_rules[rulereq_ws]() {
+						goto l32
+					}
+					{
+						position33, tokenIndex33, depth33 := position, tokenIndex, depth
+						if !_rules[ruleLogOr]() {
+							goto l34
+						}
+						goto l33
+					l34:
+						position, tokenIndex, depth = position33, tokenIndex33, depth33
+						if !_rules[ruleLogAnd]() {
+							goto l32
+						}
+					}
+				l33:
+					goto l31
+				l32:
+					position, tokenIndex, depth = position32, tokenIndex32, depth32
 				}
 				depth--
-				add(ruleLogOr, position34)
+				add(ruleLevel4, position30)
 			}
 			return true
-		l33:
-			position, tokenIndex, depth = position33, tokenIndex33, depth33
+		l29:
+			position, tokenIndex, depth = position29, tokenIndex29, depth29
 			return false
 		},
-		/* 11 LogAnd <- <('-' 'a' 'n' 'd' req_ws Level3)> */
+		/* 10 LogOr <- <('-' 'o' 'r' req_ws Level3)> */
 		func() bool {
 			position35, tokenIndex35, depth35 := position, tokenIndex, depth
 			{
@@ -934,15 +912,11 @@ func (p *DynamlGrammar) Init() {
 					goto l35
 				}
 				position++
-				if buffer[position] != rune('a') {
+				if buffer[position] != rune('o') {
 					goto l35
 				}
 				position++
-				if buffer[position] != rune('n') {
-					goto l35
-				}
-				position++
-				if buffer[position] != rune('d') {
+				if buffer[position] != rune('r') {
 					goto l35
 				}
 				position++
@@ -953,217 +927,229 @@ func (p *DynamlGrammar) Init() {
 					goto l35
 				}
 				depth--
-				add(ruleLogAnd, position36)
+				add(ruleLogOr, position36)
 			}
 			return true
 		l35:
 			position, tokenIndex, depth = position35, tokenIndex35, depth35
 			return false
 		},
-		/* 12 Level3 <- <(Level2 (req_ws Comparison)*)> */
+		/* 11 LogAnd <- <('-' 'a' 'n' 'd' req_ws Level3)> */
 		func() bool {
 			position37, tokenIndex37, depth37 := position, tokenIndex, depth
 			{
 				position38 := position
 				depth++
-				if !_rules[ruleLevel2]() {
+				if buffer[position] != rune('-') {
 					goto l37
 				}
-			l39:
-				{
-					position40, tokenIndex40, depth40 := position, tokenIndex, depth
-					if !_rules[rulereq_ws]() {
-						goto l40
-					}
-					if !_rules[ruleComparison]() {
-						goto l40
-					}
-					goto l39
-				l40:
-					position, tokenIndex, depth = position40, tokenIndex40, depth40
+				position++
+				if buffer[position] != rune('a') {
+					goto l37
+				}
+				position++
+				if buffer[position] != rune('n') {
+					goto l37
+				}
+				position++
+				if buffer[position] != rune('d') {
+					goto l37
+				}
+				position++
+				if !_rules[rulereq_ws]() {
+					goto l37
+				}
+				if !_rules[ruleLevel3]() {
+					goto l37
 				}
 				depth--
-				add(ruleLevel3, position38)
+				add(ruleLogAnd, position38)
 			}
 			return true
 		l37:
 			position, tokenIndex, depth = position37, tokenIndex37, depth37
 			return false
 		},
-		/* 13 Comparison <- <(CompareOp req_ws Level2)> */
+		/* 12 Level3 <- <(Level2 (req_ws Comparison)*)> */
 		func() bool {
-			position41, tokenIndex41, depth41 := position, tokenIndex, depth
+			position39, tokenIndex39, depth39 := position, tokenIndex, depth
 			{
-				position42 := position
+				position40 := position
 				depth++
-				if !_rules[ruleCompareOp]() {
-					goto l41
-				}
-				if !_rules[rulereq_ws]() {
-					goto l41
-				}
 				if !_rules[ruleLevel2]() {
+					goto l39
+				}
+			l41:
+				{
+					position42, tokenIndex42, depth42 := position, tokenIndex, depth
+					if !_rules[rulereq_ws]() {
+						goto l42
+					}
+					if !_rules[ruleComparison]() {
+						goto l42
+					}
 					goto l41
+				l42:
+					position, tokenIndex, depth = position42, tokenIndex42, depth42
 				}
 				depth--
-				add(ruleComparison, position42)
+				add(ruleLevel3, position40)
 			}
 			return true
-		l41:
-			position, tokenIndex, depth = position41, tokenIndex41, depth41
+		l39:
+			position, tokenIndex, depth = position39, tokenIndex39, depth39
 			return false
 		},
-		/* 14 CompareOp <- <(('=' '=') / ('!' '=') / ('<' '=') / ('>' '=') / '>' / '<' / '>')> */
+		/* 13 Comparison <- <(CompareOp req_ws Level2)> */
 		func() bool {
 			position43, tokenIndex43, depth43 := position, tokenIndex, depth
 			{
 				position44 := position
 				depth++
-				{
-					position45, tokenIndex45, depth45 := position, tokenIndex, depth
-					if buffer[position] != rune('=') {
-						goto l46
-					}
-					position++
-					if buffer[position] != rune('=') {
-						goto l46
-					}
-					position++
-					goto l45
-				l46:
-					position, tokenIndex, depth = position45, tokenIndex45, depth45
-					if buffer[position] != rune('!') {
-						goto l47
-					}
-					position++
-					if buffer[position] != rune('=') {
-						goto l47
-					}
-					position++
-					goto l45
-				l47:
-					position, tokenIndex, depth = position45, tokenIndex45, depth45
-					if buffer[position] != rune('<') {
-						goto l48
-					}
-					position++
-					if buffer[position] != rune('=') {
-						goto l48
-					}
-					position++
-					goto l45
-				l48:
-					position, tokenIndex, depth = position45, tokenIndex45, depth45
-					if buffer[position] != rune('>') {
-						goto l49
-					}
-					position++
-					if buffer[position] != rune('=') {
-						goto l49
-					}
-					position++
-					goto l45
-				l49:
-					position, tokenIndex, depth = position45, tokenIndex45, depth45
-					if buffer[position] != rune('>') {
-						goto l50
-					}
-					position++
-					goto l45
-				l50:
-					position, tokenIndex, depth = position45, tokenIndex45, depth45
-					if buffer[position] != rune('<') {
-						goto l51
-					}
-					position++
-					goto l45
-				l51:
-					position, tokenIndex, depth = position45, tokenIndex45, depth45
-					if buffer[position] != rune('>') {
-						goto l43
-					}
-					position++
+				if !_rules[ruleCompareOp]() {
+					goto l43
 				}
-			l45:
+				if !_rules[rulereq_ws]() {
+					goto l43
+				}
+				if !_rules[ruleLevel2]() {
+					goto l43
+				}
 				depth--
-				add(ruleCompareOp, position44)
+				add(ruleComparison, position44)
 			}
 			return true
 		l43:
 			position, tokenIndex, depth = position43, tokenIndex43, depth43
 			return false
 		},
-		/* 15 Level2 <- <(Level1 (req_ws (Addition / Subtraction))*)> */
+		/* 14 CompareOp <- <(('=' '=') / ('!' '=') / ('<' '=') / ('>' '=') / '>' / '<' / '>')> */
 		func() bool {
-			position52, tokenIndex52, depth52 := position, tokenIndex, depth
+			position45, tokenIndex45, depth45 := position, tokenIndex, depth
 			{
-				position53 := position
+				position46 := position
 				depth++
-				if !_rules[ruleLevel1]() {
-					goto l52
-				}
-			l54:
 				{
-					position55, tokenIndex55, depth55 := position, tokenIndex, depth
-					if !_rules[rulereq_ws]() {
-						goto l55
+					position47, tokenIndex47, depth47 := position, tokenIndex, depth
+					if buffer[position] != rune('=') {
+						goto l48
 					}
-					{
-						position56, tokenIndex56, depth56 := position, tokenIndex, depth
-						if !_rules[ruleAddition]() {
-							goto l57
-						}
-						goto l56
-					l57:
-						position, tokenIndex, depth = position56, tokenIndex56, depth56
-						if !_rules[ruleSubtraction]() {
-							goto l55
-						}
+					position++
+					if buffer[position] != rune('=') {
+						goto l48
 					}
-				l56:
-					goto l54
-				l55:
-					position, tokenIndex, depth = position55, tokenIndex55, depth55
+					position++
+					goto l47
+				l48:
+					position, tokenIndex, depth = position47, tokenIndex47, depth47
+					if buffer[position] != rune('!') {
+						goto l49
+					}
+					position++
+					if buffer[position] != rune('=') {
+						goto l49
+					}
+					position++
+					goto l47
+				l49:
+					position, tokenIndex, depth = position47, tokenIndex47, depth47
+					if buffer[position] != rune('<') {
+						goto l50
+					}
+					position++
+					if buffer[position] != rune('=') {
+						goto l50
+					}
+					position++
+					goto l47
+				l50:
+					position, tokenIndex, depth = position47, tokenIndex47, depth47
+					if buffer[position] != rune('>') {
+						goto l51
+					}
+					position++
+					if buffer[position] != rune('=') {
+						goto l51
+					}
+					position++
+					goto l47
+				l51:
+					position, tokenIndex, depth = position47, tokenIndex47, depth47
+					if buffer[position] != rune('>') {
+						goto l52
+					}
+					position++
+					goto l47
+				l52:
+					position, tokenIndex, depth = position47, tokenIndex47, depth47
+					if buffer[position] != rune('<') {
+						goto l53
+					}
+					position++
+					goto l47
+				l53:
+					position, tokenIndex, depth = position47, tokenIndex47, depth47
+					if buffer[position] != rune('>') {
+						goto l45
+					}
+					position++
 				}
+			l47:
 				depth--
-				add(ruleLevel2, position53)
+				add(ruleCompareOp, position46)
 			}
 			return true
-		l52:
-			position, tokenIndex, depth = position52, tokenIndex52, depth52
+		l45:
+			position, tokenIndex, depth = position45, tokenIndex45, depth45
+			return false
+		},
+		/* 15 Level2 <- <(Level1 (req_ws (Addition / Subtraction))*)> */
+		func() bool {
+			position54, tokenIndex54, depth54 := position, tokenIndex, depth
+			{
+				position55 := position
+				depth++
+				if !_rules[ruleLevel1]() {
+					goto l54
+				}
+			l56:
+				{
+					position57, tokenIndex57, depth57 := position, tokenIndex, depth
+					if !_rules[rulereq_ws]() {
+						goto l57
+					}
+					{
+						position58, tokenIndex58, depth58 := position, tokenIndex, depth
+						if !_rules[ruleAddition]() {
+							goto l59
+						}
+						goto l58
+					l59:
+						position, tokenIndex, depth = position58, tokenIndex58, depth58
+						if !_rules[ruleSubtraction]() {
+							goto l57
+						}
+					}
+				l58:
+					goto l56
+				l57:
+					position, tokenIndex, depth = position57, tokenIndex57, depth57
+				}
+				depth--
+				add(ruleLevel2, position55)
+			}
+			return true
+		l54:
+			position, tokenIndex, depth = position54, tokenIndex54, depth54
 			return false
 		},
 		/* 16 Addition <- <('+' req_ws Level1)> */
-		func() bool {
-			position58, tokenIndex58, depth58 := position, tokenIndex, depth
-			{
-				position59 := position
-				depth++
-				if buffer[position] != rune('+') {
-					goto l58
-				}
-				position++
-				if !_rules[rulereq_ws]() {
-					goto l58
-				}
-				if !_rules[ruleLevel1]() {
-					goto l58
-				}
-				depth--
-				add(ruleAddition, position59)
-			}
-			return true
-		l58:
-			position, tokenIndex, depth = position58, tokenIndex58, depth58
-			return false
-		},
-		/* 17 Subtraction <- <('-' req_ws Level1)> */
 		func() bool {
 			position60, tokenIndex60, depth60 := position, tokenIndex, depth
 			{
 				position61 := position
 				depth++
-				if buffer[position] != rune('-') {
+				if buffer[position] != rune('+') {
 					goto l60
 				}
 				position++
@@ -1174,90 +1160,90 @@ func (p *DynamlGrammar) Init() {
 					goto l60
 				}
 				depth--
-				add(ruleSubtraction, position61)
+				add(ruleAddition, position61)
 			}
 			return true
 		l60:
 			position, tokenIndex, depth = position60, tokenIndex60, depth60
 			return false
 		},
-		/* 18 Level1 <- <(Level0 (req_ws (Multiplication / Division / Modulo))*)> */
+		/* 17 Subtraction <- <('-' req_ws Level1)> */
 		func() bool {
 			position62, tokenIndex62, depth62 := position, tokenIndex, depth
 			{
 				position63 := position
 				depth++
-				if !_rules[ruleLevel0]() {
+				if buffer[position] != rune('-') {
 					goto l62
 				}
-			l64:
-				{
-					position65, tokenIndex65, depth65 := position, tokenIndex, depth
-					if !_rules[rulereq_ws]() {
-						goto l65
-					}
-					{
-						position66, tokenIndex66, depth66 := position, tokenIndex, depth
-						if !_rules[ruleMultiplication]() {
-							goto l67
-						}
-						goto l66
-					l67:
-						position, tokenIndex, depth = position66, tokenIndex66, depth66
-						if !_rules[ruleDivision]() {
-							goto l68
-						}
-						goto l66
-					l68:
-						position, tokenIndex, depth = position66, tokenIndex66, depth66
-						if !_rules[ruleModulo]() {
-							goto l65
-						}
-					}
-				l66:
-					goto l64
-				l65:
-					position, tokenIndex, depth = position65, tokenIndex65, depth65
+				position++
+				if !_rules[rulereq_ws]() {
+					goto l62
+				}
+				if !_rules[ruleLevel1]() {
+					goto l62
 				}
 				depth--
-				add(ruleLevel1, position63)
+				add(ruleSubtraction, position63)
 			}
 			return true
 		l62:
 			position, tokenIndex, depth = position62, tokenIndex62, depth62
 			return false
 		},
-		/* 19 Multiplication <- <('*' req_ws Level0)> */
+		/* 18 Level1 <- <(Level0 (req_ws (Multiplication / Division / Modulo))*)> */
 		func() bool {
-			position69, tokenIndex69, depth69 := position, tokenIndex, depth
+			position64, tokenIndex64, depth64 := position, tokenIndex, depth
 			{
-				position70 := position
+				position65 := position
 				depth++
-				if buffer[position] != rune('*') {
-					goto l69
-				}
-				position++
-				if !_rules[rulereq_ws]() {
-					goto l69
-				}
 				if !_rules[ruleLevel0]() {
-					goto l69
+					goto l64
+				}
+			l66:
+				{
+					position67, tokenIndex67, depth67 := position, tokenIndex, depth
+					if !_rules[rulereq_ws]() {
+						goto l67
+					}
+					{
+						position68, tokenIndex68, depth68 := position, tokenIndex, depth
+						if !_rules[ruleMultiplication]() {
+							goto l69
+						}
+						goto l68
+					l69:
+						position, tokenIndex, depth = position68, tokenIndex68, depth68
+						if !_rules[ruleDivision]() {
+							goto l70
+						}
+						goto l68
+					l70:
+						position, tokenIndex, depth = position68, tokenIndex68, depth68
+						if !_rules[ruleModulo]() {
+							goto l67
+						}
+					}
+				l68:
+					goto l66
+				l67:
+					position, tokenIndex, depth = position67, tokenIndex67, depth67
 				}
 				depth--
-				add(ruleMultiplication, position70)
+				add(ruleLevel1, position65)
 			}
 			return true
-		l69:
-			position, tokenIndex, depth = position69, tokenIndex69, depth69
+		l64:
+			position, tokenIndex, depth = position64, tokenIndex64, depth64
 			return false
 		},
-		/* 20 Division <- <('/' req_ws Level0)> */
+		/* 19 Multiplication <- <('*' req_ws Level0)> */
 		func() bool {
 			position71, tokenIndex71, depth71 := position, tokenIndex, depth
 			{
 				position72 := position
 				depth++
-				if buffer[position] != rune('/') {
+				if buffer[position] != rune('*') {
 					goto l71
 				}
 				position++
@@ -1268,20 +1254,20 @@ func (p *DynamlGrammar) Init() {
 					goto l71
 				}
 				depth--
-				add(ruleDivision, position72)
+				add(ruleMultiplication, position72)
 			}
 			return true
 		l71:
 			position, tokenIndex, depth = position71, tokenIndex71, depth71
 			return false
 		},
-		/* 21 Modulo <- <('%' req_ws Level0)> */
+		/* 20 Division <- <('/' req_ws Level0)> */
 		func() bool {
 			position73, tokenIndex73, depth73 := position, tokenIndex, depth
 			{
 				position74 := position
 				depth++
-				if buffer[position] != rune('%') {
+				if buffer[position] != rune('/') {
 					goto l73
 				}
 				position++
@@ -1292,894 +1278,876 @@ func (p *DynamlGrammar) Init() {
 					goto l73
 				}
 				depth--
-				add(ruleModulo, position74)
+				add(ruleDivision, position74)
 			}
 			return true
 		l73:
 			position, tokenIndex, depth = position73, tokenIndex73, depth73
 			return false
 		},
-		/* 22 Level0 <- <(QualifiedExpression / Not / Call / Grouped / Boolean / Nil / String / Integer / List / Range / Merge / Auto / Mapping / Lambda / Reference)> */
+		/* 21 Modulo <- <('%' req_ws Level0)> */
 		func() bool {
 			position75, tokenIndex75, depth75 := position, tokenIndex, depth
 			{
 				position76 := position
 				depth++
-				{
-					position77, tokenIndex77, depth77 := position, tokenIndex, depth
-					if !_rules[ruleQualifiedExpression]() {
-						goto l78
-					}
-					goto l77
-				l78:
-					position, tokenIndex, depth = position77, tokenIndex77, depth77
-					if !_rules[ruleNot]() {
-						goto l79
-					}
-					goto l77
-				l79:
-					position, tokenIndex, depth = position77, tokenIndex77, depth77
-					if !_rules[ruleCall]() {
-						goto l80
-					}
-					goto l77
-				l80:
-					position, tokenIndex, depth = position77, tokenIndex77, depth77
-					if !_rules[ruleGrouped]() {
-						goto l81
-					}
-					goto l77
-				l81:
-					position, tokenIndex, depth = position77, tokenIndex77, depth77
-					if !_rules[ruleBoolean]() {
-						goto l82
-					}
-					goto l77
-				l82:
-					position, tokenIndex, depth = position77, tokenIndex77, depth77
-					if !_rules[ruleNil]() {
-						goto l83
-					}
-					goto l77
-				l83:
-					position, tokenIndex, depth = position77, tokenIndex77, depth77
-					if !_rules[ruleString]() {
-						goto l84
-					}
-					goto l77
-				l84:
-					position, tokenIndex, depth = position77, tokenIndex77, depth77
-					if !_rules[ruleInteger]() {
-						goto l85
-					}
-					goto l77
-				l85:
-					position, tokenIndex, depth = position77, tokenIndex77, depth77
-					if !_rules[ruleList]() {
-						goto l86
-					}
-					goto l77
-				l86:
-					position, tokenIndex, depth = position77, tokenIndex77, depth77
-					if !_rules[ruleRange]() {
-						goto l87
-					}
-					goto l77
-				l87:
-					position, tokenIndex, depth = position77, tokenIndex77, depth77
-					if !_rules[ruleMerge]() {
-						goto l88
-					}
-					goto l77
-				l88:
-					position, tokenIndex, depth = position77, tokenIndex77, depth77
-					if !_rules[ruleAuto]() {
-						goto l89
-					}
-					goto l77
-				l89:
-					position, tokenIndex, depth = position77, tokenIndex77, depth77
-					if !_rules[ruleMapping]() {
-						goto l90
-					}
-					goto l77
-				l90:
-					position, tokenIndex, depth = position77, tokenIndex77, depth77
-					if !_rules[ruleLambda]() {
-						goto l91
-					}
-					goto l77
-				l91:
-					position, tokenIndex, depth = position77, tokenIndex77, depth77
-					if !_rules[ruleReference]() {
-						goto l75
-					}
+				if buffer[position] != rune('%') {
+					goto l75
 				}
-			l77:
+				position++
+				if !_rules[rulereq_ws]() {
+					goto l75
+				}
+				if !_rules[ruleLevel0]() {
+					goto l75
+				}
 				depth--
-				add(ruleLevel0, position76)
+				add(ruleModulo, position76)
 			}
 			return true
 		l75:
 			position, tokenIndex, depth = position75, tokenIndex75, depth75
 			return false
 		},
-		/* 23 QualifiedExpression <- <((Call / Grouped / List / Range) '.' FollowUpRef)> */
+		/* 22 Level0 <- <(QualifiedExpression / Not / Call / Grouped / Boolean / Nil / String / Integer / List / Range / Merge / Auto / Mapping / Lambda / Reference)> */
 		func() bool {
-			position92, tokenIndex92, depth92 := position, tokenIndex, depth
+			position77, tokenIndex77, depth77 := position, tokenIndex, depth
 			{
-				position93 := position
+				position78 := position
 				depth++
 				{
-					position94, tokenIndex94, depth94 := position, tokenIndex, depth
+					position79, tokenIndex79, depth79 := position, tokenIndex, depth
+					if !_rules[ruleQualifiedExpression]() {
+						goto l80
+					}
+					goto l79
+				l80:
+					position, tokenIndex, depth = position79, tokenIndex79, depth79
+					if !_rules[ruleNot]() {
+						goto l81
+					}
+					goto l79
+				l81:
+					position, tokenIndex, depth = position79, tokenIndex79, depth79
 					if !_rules[ruleCall]() {
-						goto l95
+						goto l82
 					}
-					goto l94
-				l95:
-					position, tokenIndex, depth = position94, tokenIndex94, depth94
+					goto l79
+				l82:
+					position, tokenIndex, depth = position79, tokenIndex79, depth79
 					if !_rules[ruleGrouped]() {
-						goto l96
+						goto l83
 					}
-					goto l94
-				l96:
-					position, tokenIndex, depth = position94, tokenIndex94, depth94
+					goto l79
+				l83:
+					position, tokenIndex, depth = position79, tokenIndex79, depth79
+					if !_rules[ruleBoolean]() {
+						goto l84
+					}
+					goto l79
+				l84:
+					position, tokenIndex, depth = position79, tokenIndex79, depth79
+					if !_rules[ruleNil]() {
+						goto l85
+					}
+					goto l79
+				l85:
+					position, tokenIndex, depth = position79, tokenIndex79, depth79
+					if !_rules[ruleString]() {
+						goto l86
+					}
+					goto l79
+				l86:
+					position, tokenIndex, depth = position79, tokenIndex79, depth79
+					if !_rules[ruleInteger]() {
+						goto l87
+					}
+					goto l79
+				l87:
+					position, tokenIndex, depth = position79, tokenIndex79, depth79
 					if !_rules[ruleList]() {
-						goto l97
+						goto l88
 					}
-					goto l94
-				l97:
-					position, tokenIndex, depth = position94, tokenIndex94, depth94
+					goto l79
+				l88:
+					position, tokenIndex, depth = position79, tokenIndex79, depth79
 					if !_rules[ruleRange]() {
+						goto l89
+					}
+					goto l79
+				l89:
+					position, tokenIndex, depth = position79, tokenIndex79, depth79
+					if !_rules[ruleMerge]() {
+						goto l90
+					}
+					goto l79
+				l90:
+					position, tokenIndex, depth = position79, tokenIndex79, depth79
+					if !_rules[ruleAuto]() {
+						goto l91
+					}
+					goto l79
+				l91:
+					position, tokenIndex, depth = position79, tokenIndex79, depth79
+					if !_rules[ruleMapping]() {
 						goto l92
 					}
+					goto l79
+				l92:
+					position, tokenIndex, depth = position79, tokenIndex79, depth79
+					if !_rules[ruleLambda]() {
+						goto l93
+					}
+					goto l79
+				l93:
+					position, tokenIndex, depth = position79, tokenIndex79, depth79
+					if !_rules[ruleReference]() {
+						goto l77
+					}
 				}
-			l94:
+			l79:
+				depth--
+				add(ruleLevel0, position78)
+			}
+			return true
+		l77:
+			position, tokenIndex, depth = position77, tokenIndex77, depth77
+			return false
+		},
+		/* 23 QualifiedExpression <- <((Call / Grouped / List / Range) '.' FollowUpRef)> */
+		func() bool {
+			position94, tokenIndex94, depth94 := position, tokenIndex, depth
+			{
+				position95 := position
+				depth++
+				{
+					position96, tokenIndex96, depth96 := position, tokenIndex, depth
+					if !_rules[ruleCall]() {
+						goto l97
+					}
+					goto l96
+				l97:
+					position, tokenIndex, depth = position96, tokenIndex96, depth96
+					if !_rules[ruleGrouped]() {
+						goto l98
+					}
+					goto l96
+				l98:
+					position, tokenIndex, depth = position96, tokenIndex96, depth96
+					if !_rules[ruleList]() {
+						goto l99
+					}
+					goto l96
+				l99:
+					position, tokenIndex, depth = position96, tokenIndex96, depth96
+					if !_rules[ruleRange]() {
+						goto l94
+					}
+				}
+			l96:
 				if buffer[position] != rune('.') {
-					goto l92
+					goto l94
 				}
 				position++
 				if !_rules[ruleFollowUpRef]() {
-					goto l92
+					goto l94
 				}
 				depth--
-				add(ruleQualifiedExpression, position93)
+				add(ruleQualifiedExpression, position95)
 			}
 			return true
-		l92:
-			position, tokenIndex, depth = position92, tokenIndex92, depth92
+		l94:
+			position, tokenIndex, depth = position94, tokenIndex94, depth94
 			return false
 		},
 		/* 24 Not <- <('!' ws Level0)> */
-		func() bool {
-			position98, tokenIndex98, depth98 := position, tokenIndex, depth
-			{
-				position99 := position
-				depth++
-				if buffer[position] != rune('!') {
-					goto l98
-				}
-				position++
-				if !_rules[rulews]() {
-					goto l98
-				}
-				if !_rules[ruleLevel0]() {
-					goto l98
-				}
-				depth--
-				add(ruleNot, position99)
-			}
-			return true
-		l98:
-			position, tokenIndex, depth = position98, tokenIndex98, depth98
-			return false
-		},
-		/* 25 Grouped <- <('(' Expression ')')> */
 		func() bool {
 			position100, tokenIndex100, depth100 := position, tokenIndex, depth
 			{
 				position101 := position
 				depth++
-				if buffer[position] != rune('(') {
+				if buffer[position] != rune('!') {
 					goto l100
 				}
 				position++
-				if !_rules[ruleExpression]() {
+				if !_rules[rulews]() {
 					goto l100
 				}
-				if buffer[position] != rune(')') {
+				if !_rules[ruleLevel0]() {
 					goto l100
 				}
-				position++
 				depth--
-				add(ruleGrouped, position101)
+				add(ruleNot, position101)
 			}
 			return true
 		l100:
 			position, tokenIndex, depth = position100, tokenIndex100, depth100
 			return false
 		},
-		/* 26 Range <- <('[' Expression ('.' '.') Expression ']')> */
+		/* 25 Grouped <- <('(' Expression ')')> */
 		func() bool {
 			position102, tokenIndex102, depth102 := position, tokenIndex, depth
 			{
 				position103 := position
 				depth++
-				if buffer[position] != rune('[') {
+				if buffer[position] != rune('(') {
 					goto l102
 				}
 				position++
 				if !_rules[ruleExpression]() {
 					goto l102
 				}
-				if buffer[position] != rune('.') {
-					goto l102
-				}
-				position++
-				if buffer[position] != rune('.') {
-					goto l102
-				}
-				position++
-				if !_rules[ruleExpression]() {
-					goto l102
-				}
-				if buffer[position] != rune(']') {
+				if buffer[position] != rune(')') {
 					goto l102
 				}
 				position++
 				depth--
-				add(ruleRange, position103)
+				add(ruleGrouped, position103)
 			}
 			return true
 		l102:
 			position, tokenIndex, depth = position102, tokenIndex102, depth102
 			return false
 		},
-		/* 27 Call <- <((Reference / Grouped) '(' Arguments ')')> */
+		/* 26 Range <- <('[' Expression ('.' '.') Expression ']')> */
 		func() bool {
 			position104, tokenIndex104, depth104 := position, tokenIndex, depth
 			{
 				position105 := position
 				depth++
-				{
-					position106, tokenIndex106, depth106 := position, tokenIndex, depth
-					if !_rules[ruleReference]() {
-						goto l107
-					}
-					goto l106
-				l107:
-					position, tokenIndex, depth = position106, tokenIndex106, depth106
-					if !_rules[ruleGrouped]() {
-						goto l104
-					}
-				}
-			l106:
-				if buffer[position] != rune('(') {
+				if buffer[position] != rune('[') {
 					goto l104
 				}
 				position++
-				if !_rules[ruleArguments]() {
+				if !_rules[ruleExpression]() {
 					goto l104
 				}
-				if buffer[position] != rune(')') {
+				if buffer[position] != rune('.') {
+					goto l104
+				}
+				position++
+				if buffer[position] != rune('.') {
+					goto l104
+				}
+				position++
+				if !_rules[ruleExpression]() {
+					goto l104
+				}
+				if buffer[position] != rune(']') {
 					goto l104
 				}
 				position++
 				depth--
-				add(ruleCall, position105)
+				add(ruleRange, position105)
 			}
 			return true
 		l104:
 			position, tokenIndex, depth = position104, tokenIndex104, depth104
 			return false
 		},
-		/* 28 Name <- <([a-z] / [A-Z] / [0-9] / '_')+> */
+		/* 27 Call <- <((Reference / Grouped) '(' Arguments ')')> */
 		func() bool {
-			position108, tokenIndex108, depth108 := position, tokenIndex, depth
+			position106, tokenIndex106, depth106 := position, tokenIndex, depth
 			{
-				position109 := position
+				position107 := position
 				depth++
 				{
-					position112, tokenIndex112, depth112 := position, tokenIndex, depth
+					position108, tokenIndex108, depth108 := position, tokenIndex, depth
+					if !_rules[ruleReference]() {
+						goto l109
+					}
+					goto l108
+				l109:
+					position, tokenIndex, depth = position108, tokenIndex108, depth108
+					if !_rules[ruleGrouped]() {
+						goto l106
+					}
+				}
+			l108:
+				if buffer[position] != rune('(') {
+					goto l106
+				}
+				position++
+				if !_rules[ruleArguments]() {
+					goto l106
+				}
+				if buffer[position] != rune(')') {
+					goto l106
+				}
+				position++
+				depth--
+				add(ruleCall, position107)
+			}
+			return true
+		l106:
+			position, tokenIndex, depth = position106, tokenIndex106, depth106
+			return false
+		},
+		/* 28 Name <- <([a-z] / [A-Z] / [0-9] / '_')+> */
+		func() bool {
+			position110, tokenIndex110, depth110 := position, tokenIndex, depth
+			{
+				position111 := position
+				depth++
+				{
+					position114, tokenIndex114, depth114 := position, tokenIndex, depth
 					if c := buffer[position]; c < rune('a') || c > rune('z') {
-						goto l113
-					}
-					position++
-					goto l112
-				l113:
-					position, tokenIndex, depth = position112, tokenIndex112, depth112
-					if c := buffer[position]; c < rune('A') || c > rune('Z') {
-						goto l114
-					}
-					position++
-					goto l112
-				l114:
-					position, tokenIndex, depth = position112, tokenIndex112, depth112
-					if c := buffer[position]; c < rune('0') || c > rune('9') {
 						goto l115
 					}
 					position++
-					goto l112
+					goto l114
 				l115:
-					position, tokenIndex, depth = position112, tokenIndex112, depth112
+					position, tokenIndex, depth = position114, tokenIndex114, depth114
+					if c := buffer[position]; c < rune('A') || c > rune('Z') {
+						goto l116
+					}
+					position++
+					goto l114
+				l116:
+					position, tokenIndex, depth = position114, tokenIndex114, depth114
+					if c := buffer[position]; c < rune('0') || c > rune('9') {
+						goto l117
+					}
+					position++
+					goto l114
+				l117:
+					position, tokenIndex, depth = position114, tokenIndex114, depth114
 					if buffer[position] != rune('_') {
-						goto l108
+						goto l110
 					}
 					position++
 				}
+			l114:
 			l112:
-			l110:
 				{
-					position111, tokenIndex111, depth111 := position, tokenIndex, depth
+					position113, tokenIndex113, depth113 := position, tokenIndex, depth
 					{
-						position116, tokenIndex116, depth116 := position, tokenIndex, depth
+						position118, tokenIndex118, depth118 := position, tokenIndex, depth
 						if c := buffer[position]; c < rune('a') || c > rune('z') {
-							goto l117
-						}
-						position++
-						goto l116
-					l117:
-						position, tokenIndex, depth = position116, tokenIndex116, depth116
-						if c := buffer[position]; c < rune('A') || c > rune('Z') {
-							goto l118
-						}
-						position++
-						goto l116
-					l118:
-						position, tokenIndex, depth = position116, tokenIndex116, depth116
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
 							goto l119
 						}
 						position++
-						goto l116
+						goto l118
 					l119:
-						position, tokenIndex, depth = position116, tokenIndex116, depth116
+						position, tokenIndex, depth = position118, tokenIndex118, depth118
+						if c := buffer[position]; c < rune('A') || c > rune('Z') {
+							goto l120
+						}
+						position++
+						goto l118
+					l120:
+						position, tokenIndex, depth = position118, tokenIndex118, depth118
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l121
+						}
+						position++
+						goto l118
+					l121:
+						position, tokenIndex, depth = position118, tokenIndex118, depth118
 						if buffer[position] != rune('_') {
-							goto l111
+							goto l113
 						}
 						position++
 					}
-				l116:
-					goto l110
-				l111:
-					position, tokenIndex, depth = position111, tokenIndex111, depth111
+				l118:
+					goto l112
+				l113:
+					position, tokenIndex, depth = position113, tokenIndex113, depth113
 				}
 				depth--
-				add(ruleName, position109)
+				add(ruleName, position111)
 			}
 			return true
-		l108:
-			position, tokenIndex, depth = position108, tokenIndex108, depth108
+		l110:
+			position, tokenIndex, depth = position110, tokenIndex110, depth110
 			return false
 		},
 		/* 29 Arguments <- <(Expression NextExpression*)> */
 		func() bool {
-			position120, tokenIndex120, depth120 := position, tokenIndex, depth
+			position122, tokenIndex122, depth122 := position, tokenIndex, depth
 			{
-				position121 := position
+				position123 := position
 				depth++
 				if !_rules[ruleExpression]() {
-					goto l120
-				}
-			l122:
-				{
-					position123, tokenIndex123, depth123 := position, tokenIndex, depth
-					if !_rules[ruleNextExpression]() {
-						goto l123
-					}
 					goto l122
-				l123:
-					position, tokenIndex, depth = position123, tokenIndex123, depth123
+				}
+			l124:
+				{
+					position125, tokenIndex125, depth125 := position, tokenIndex, depth
+					if !_rules[ruleNextExpression]() {
+						goto l125
+					}
+					goto l124
+				l125:
+					position, tokenIndex, depth = position125, tokenIndex125, depth125
 				}
 				depth--
-				add(ruleArguments, position121)
+				add(ruleArguments, position123)
 			}
 			return true
-		l120:
-			position, tokenIndex, depth = position120, tokenIndex120, depth120
+		l122:
+			position, tokenIndex, depth = position122, tokenIndex122, depth122
 			return false
 		},
 		/* 30 NextExpression <- <(',' Expression)> */
-		func() bool {
-			position124, tokenIndex124, depth124 := position, tokenIndex, depth
-			{
-				position125 := position
-				depth++
-				if buffer[position] != rune(',') {
-					goto l124
-				}
-				position++
-				if !_rules[ruleExpression]() {
-					goto l124
-				}
-				depth--
-				add(ruleNextExpression, position125)
-			}
-			return true
-		l124:
-			position, tokenIndex, depth = position124, tokenIndex124, depth124
-			return false
-		},
-		/* 31 Integer <- <('-'? ([0-9] / '_')+)> */
 		func() bool {
 			position126, tokenIndex126, depth126 := position, tokenIndex, depth
 			{
 				position127 := position
 				depth++
-				{
-					position128, tokenIndex128, depth128 := position, tokenIndex, depth
-					if buffer[position] != rune('-') {
-						goto l128
-					}
-					position++
-					goto l129
-				l128:
-					position, tokenIndex, depth = position128, tokenIndex128, depth128
+				if buffer[position] != rune(',') {
+					goto l126
 				}
-			l129:
-				{
-					position132, tokenIndex132, depth132 := position, tokenIndex, depth
-					if c := buffer[position]; c < rune('0') || c > rune('9') {
-						goto l133
-					}
-					position++
-					goto l132
-				l133:
-					position, tokenIndex, depth = position132, tokenIndex132, depth132
-					if buffer[position] != rune('_') {
-						goto l126
-					}
-					position++
-				}
-			l132:
-			l130:
-				{
-					position131, tokenIndex131, depth131 := position, tokenIndex, depth
-					{
-						position134, tokenIndex134, depth134 := position, tokenIndex, depth
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l135
-						}
-						position++
-						goto l134
-					l135:
-						position, tokenIndex, depth = position134, tokenIndex134, depth134
-						if buffer[position] != rune('_') {
-							goto l131
-						}
-						position++
-					}
-				l134:
-					goto l130
-				l131:
-					position, tokenIndex, depth = position131, tokenIndex131, depth131
+				position++
+				if !_rules[ruleExpression]() {
+					goto l126
 				}
 				depth--
-				add(ruleInteger, position127)
+				add(ruleNextExpression, position127)
 			}
 			return true
 		l126:
 			position, tokenIndex, depth = position126, tokenIndex126, depth126
 			return false
 		},
+		/* 31 Integer <- <('-'? ([0-9] / '_')+)> */
+		func() bool {
+			position128, tokenIndex128, depth128 := position, tokenIndex, depth
+			{
+				position129 := position
+				depth++
+				{
+					position130, tokenIndex130, depth130 := position, tokenIndex, depth
+					if buffer[position] != rune('-') {
+						goto l130
+					}
+					position++
+					goto l131
+				l130:
+					position, tokenIndex, depth = position130, tokenIndex130, depth130
+				}
+			l131:
+				{
+					position134, tokenIndex134, depth134 := position, tokenIndex, depth
+					if c := buffer[position]; c < rune('0') || c > rune('9') {
+						goto l135
+					}
+					position++
+					goto l134
+				l135:
+					position, tokenIndex, depth = position134, tokenIndex134, depth134
+					if buffer[position] != rune('_') {
+						goto l128
+					}
+					position++
+				}
+			l134:
+			l132:
+				{
+					position133, tokenIndex133, depth133 := position, tokenIndex, depth
+					{
+						position136, tokenIndex136, depth136 := position, tokenIndex, depth
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l137
+						}
+						position++
+						goto l136
+					l137:
+						position, tokenIndex, depth = position136, tokenIndex136, depth136
+						if buffer[position] != rune('_') {
+							goto l133
+						}
+						position++
+					}
+				l136:
+					goto l132
+				l133:
+					position, tokenIndex, depth = position133, tokenIndex133, depth133
+				}
+				depth--
+				add(ruleInteger, position129)
+			}
+			return true
+		l128:
+			position, tokenIndex, depth = position128, tokenIndex128, depth128
+			return false
+		},
 		/* 32 String <- <('"' (('\\' '"') / (!'"' .))* '"')> */
 		func() bool {
-			position136, tokenIndex136, depth136 := position, tokenIndex, depth
+			position138, tokenIndex138, depth138 := position, tokenIndex, depth
 			{
-				position137 := position
+				position139 := position
 				depth++
 				if buffer[position] != rune('"') {
-					goto l136
+					goto l138
 				}
 				position++
-			l138:
+			l140:
 				{
-					position139, tokenIndex139, depth139 := position, tokenIndex, depth
+					position141, tokenIndex141, depth141 := position, tokenIndex, depth
 					{
-						position140, tokenIndex140, depth140 := position, tokenIndex, depth
+						position142, tokenIndex142, depth142 := position, tokenIndex, depth
 						if buffer[position] != rune('\\') {
-							goto l141
+							goto l143
 						}
 						position++
 						if buffer[position] != rune('"') {
-							goto l141
+							goto l143
 						}
 						position++
-						goto l140
-					l141:
-						position, tokenIndex, depth = position140, tokenIndex140, depth140
+						goto l142
+					l143:
+						position, tokenIndex, depth = position142, tokenIndex142, depth142
 						{
-							position142, tokenIndex142, depth142 := position, tokenIndex, depth
+							position144, tokenIndex144, depth144 := position, tokenIndex, depth
 							if buffer[position] != rune('"') {
-								goto l142
+								goto l144
 							}
 							position++
-							goto l139
-						l142:
-							position, tokenIndex, depth = position142, tokenIndex142, depth142
+							goto l141
+						l144:
+							position, tokenIndex, depth = position144, tokenIndex144, depth144
 						}
 						if !matchDot() {
-							goto l139
+							goto l141
 						}
 					}
-				l140:
-					goto l138
-				l139:
-					position, tokenIndex, depth = position139, tokenIndex139, depth139
+				l142:
+					goto l140
+				l141:
+					position, tokenIndex, depth = position141, tokenIndex141, depth141
 				}
 				if buffer[position] != rune('"') {
-					goto l136
+					goto l138
 				}
 				position++
 				depth--
-				add(ruleString, position137)
+				add(ruleString, position139)
 			}
 			return true
-		l136:
-			position, tokenIndex, depth = position136, tokenIndex136, depth136
+		l138:
+			position, tokenIndex, depth = position138, tokenIndex138, depth138
 			return false
 		},
 		/* 33 Boolean <- <(('t' 'r' 'u' 'e') / ('f' 'a' 'l' 's' 'e'))> */
 		func() bool {
-			position143, tokenIndex143, depth143 := position, tokenIndex, depth
+			position145, tokenIndex145, depth145 := position, tokenIndex, depth
 			{
-				position144 := position
+				position146 := position
 				depth++
 				{
-					position145, tokenIndex145, depth145 := position, tokenIndex, depth
+					position147, tokenIndex147, depth147 := position, tokenIndex, depth
 					if buffer[position] != rune('t') {
-						goto l146
+						goto l148
 					}
 					position++
 					if buffer[position] != rune('r') {
-						goto l146
+						goto l148
 					}
 					position++
 					if buffer[position] != rune('u') {
-						goto l146
+						goto l148
 					}
 					position++
 					if buffer[position] != rune('e') {
-						goto l146
+						goto l148
 					}
 					position++
-					goto l145
-				l146:
-					position, tokenIndex, depth = position145, tokenIndex145, depth145
+					goto l147
+				l148:
+					position, tokenIndex, depth = position147, tokenIndex147, depth147
 					if buffer[position] != rune('f') {
-						goto l143
+						goto l145
 					}
 					position++
 					if buffer[position] != rune('a') {
-						goto l143
+						goto l145
 					}
 					position++
 					if buffer[position] != rune('l') {
-						goto l143
+						goto l145
 					}
 					position++
 					if buffer[position] != rune('s') {
-						goto l143
+						goto l145
 					}
 					position++
 					if buffer[position] != rune('e') {
-						goto l143
+						goto l145
 					}
 					position++
 				}
-			l145:
+			l147:
 				depth--
-				add(ruleBoolean, position144)
+				add(ruleBoolean, position146)
 			}
 			return true
-		l143:
-			position, tokenIndex, depth = position143, tokenIndex143, depth143
+		l145:
+			position, tokenIndex, depth = position145, tokenIndex145, depth145
 			return false
 		},
 		/* 34 Nil <- <(('n' 'i' 'l') / '~')> */
 		func() bool {
-			position147, tokenIndex147, depth147 := position, tokenIndex, depth
+			position149, tokenIndex149, depth149 := position, tokenIndex, depth
 			{
-				position148 := position
+				position150 := position
 				depth++
 				{
-					position149, tokenIndex149, depth149 := position, tokenIndex, depth
+					position151, tokenIndex151, depth151 := position, tokenIndex, depth
 					if buffer[position] != rune('n') {
-						goto l150
+						goto l152
 					}
 					position++
 					if buffer[position] != rune('i') {
-						goto l150
+						goto l152
 					}
 					position++
 					if buffer[position] != rune('l') {
-						goto l150
+						goto l152
 					}
 					position++
-					goto l149
-				l150:
-					position, tokenIndex, depth = position149, tokenIndex149, depth149
+					goto l151
+				l152:
+					position, tokenIndex, depth = position151, tokenIndex151, depth151
 					if buffer[position] != rune('~') {
-						goto l147
+						goto l149
 					}
 					position++
 				}
-			l149:
+			l151:
 				depth--
-				add(ruleNil, position148)
+				add(ruleNil, position150)
 			}
 			return true
-		l147:
-			position, tokenIndex, depth = position147, tokenIndex147, depth147
+		l149:
+			position, tokenIndex, depth = position149, tokenIndex149, depth149
 			return false
 		},
 		/* 35 List <- <('[' Contents? ']')> */
 		func() bool {
-			position151, tokenIndex151, depth151 := position, tokenIndex, depth
+			position153, tokenIndex153, depth153 := position, tokenIndex, depth
 			{
-				position152 := position
+				position154 := position
 				depth++
 				if buffer[position] != rune('[') {
-					goto l151
+					goto l153
 				}
 				position++
 				{
-					position153, tokenIndex153, depth153 := position, tokenIndex, depth
+					position155, tokenIndex155, depth155 := position, tokenIndex, depth
 					if !_rules[ruleContents]() {
-						goto l153
+						goto l155
 					}
-					goto l154
-				l153:
-					position, tokenIndex, depth = position153, tokenIndex153, depth153
+					goto l156
+				l155:
+					position, tokenIndex, depth = position155, tokenIndex155, depth155
 				}
-			l154:
+			l156:
 				if buffer[position] != rune(']') {
-					goto l151
+					goto l153
 				}
 				position++
 				depth--
-				add(ruleList, position152)
+				add(ruleList, position154)
 			}
 			return true
-		l151:
-			position, tokenIndex, depth = position151, tokenIndex151, depth151
+		l153:
+			position, tokenIndex, depth = position153, tokenIndex153, depth153
 			return false
 		},
 		/* 36 Contents <- <(Expression NextExpression*)> */
 		func() bool {
-			position155, tokenIndex155, depth155 := position, tokenIndex, depth
+			position157, tokenIndex157, depth157 := position, tokenIndex, depth
 			{
-				position156 := position
+				position158 := position
 				depth++
 				if !_rules[ruleExpression]() {
-					goto l155
-				}
-			l157:
-				{
-					position158, tokenIndex158, depth158 := position, tokenIndex, depth
-					if !_rules[ruleNextExpression]() {
-						goto l158
-					}
 					goto l157
-				l158:
-					position, tokenIndex, depth = position158, tokenIndex158, depth158
+				}
+			l159:
+				{
+					position160, tokenIndex160, depth160 := position, tokenIndex, depth
+					if !_rules[ruleNextExpression]() {
+						goto l160
+					}
+					goto l159
+				l160:
+					position, tokenIndex, depth = position160, tokenIndex160, depth160
 				}
 				depth--
-				add(ruleContents, position156)
+				add(ruleContents, position158)
 			}
 			return true
-		l155:
-			position, tokenIndex, depth = position155, tokenIndex155, depth155
+		l157:
+			position, tokenIndex, depth = position157, tokenIndex157, depth157
 			return false
 		},
 		/* 37 Merge <- <(RefMerge / SimpleMerge)> */
 		func() bool {
-			position159, tokenIndex159, depth159 := position, tokenIndex, depth
+			position161, tokenIndex161, depth161 := position, tokenIndex, depth
 			{
-				position160 := position
+				position162 := position
 				depth++
 				{
-					position161, tokenIndex161, depth161 := position, tokenIndex, depth
+					position163, tokenIndex163, depth163 := position, tokenIndex, depth
 					if !_rules[ruleRefMerge]() {
-						goto l162
+						goto l164
 					}
-					goto l161
-				l162:
-					position, tokenIndex, depth = position161, tokenIndex161, depth161
+					goto l163
+				l164:
+					position, tokenIndex, depth = position163, tokenIndex163, depth163
 					if !_rules[ruleSimpleMerge]() {
-						goto l159
+						goto l161
 					}
 				}
-			l161:
+			l163:
 				depth--
-				add(ruleMerge, position160)
+				add(ruleMerge, position162)
 			}
 			return true
-		l159:
-			position, tokenIndex, depth = position159, tokenIndex159, depth159
+		l161:
+			position, tokenIndex, depth = position161, tokenIndex161, depth161
 			return false
 		},
 		/* 38 RefMerge <- <('m' 'e' 'r' 'g' 'e' !(req_ws Required) (req_ws (Replace / On))? req_ws Reference)> */
 		func() bool {
-			position163, tokenIndex163, depth163 := position, tokenIndex, depth
+			position165, tokenIndex165, depth165 := position, tokenIndex, depth
 			{
-				position164 := position
+				position166 := position
 				depth++
 				if buffer[position] != rune('m') {
-					goto l163
+					goto l165
 				}
 				position++
 				if buffer[position] != rune('e') {
-					goto l163
+					goto l165
 				}
 				position++
 				if buffer[position] != rune('r') {
-					goto l163
+					goto l165
 				}
 				position++
 				if buffer[position] != rune('g') {
-					goto l163
+					goto l165
 				}
 				position++
 				if buffer[position] != rune('e') {
-					goto l163
+					goto l165
 				}
 				position++
 				{
-					position165, tokenIndex165, depth165 := position, tokenIndex, depth
+					position167, tokenIndex167, depth167 := position, tokenIndex, depth
 					if !_rules[rulereq_ws]() {
-						goto l165
+						goto l167
 					}
 					if !_rules[ruleRequired]() {
-						goto l165
+						goto l167
 					}
-					goto l163
-				l165:
-					position, tokenIndex, depth = position165, tokenIndex165, depth165
+					goto l165
+				l167:
+					position, tokenIndex, depth = position167, tokenIndex167, depth167
 				}
 				{
-					position166, tokenIndex166, depth166 := position, tokenIndex, depth
+					position168, tokenIndex168, depth168 := position, tokenIndex, depth
 					if !_rules[rulereq_ws]() {
-						goto l166
+						goto l168
 					}
 					{
-						position168, tokenIndex168, depth168 := position, tokenIndex, depth
+						position170, tokenIndex170, depth170 := position, tokenIndex, depth
 						if !_rules[ruleReplace]() {
-							goto l169
+							goto l171
 						}
-						goto l168
-					l169:
-						position, tokenIndex, depth = position168, tokenIndex168, depth168
+						goto l170
+					l171:
+						position, tokenIndex, depth = position170, tokenIndex170, depth170
 						if !_rules[ruleOn]() {
-							goto l166
+							goto l168
 						}
 					}
+				l170:
+					goto l169
 				l168:
-					goto l167
-				l166:
-					position, tokenIndex, depth = position166, tokenIndex166, depth166
+					position, tokenIndex, depth = position168, tokenIndex168, depth168
 				}
-			l167:
+			l169:
 				if !_rules[rulereq_ws]() {
-					goto l163
+					goto l165
 				}
 				if !_rules[ruleReference]() {
-					goto l163
+					goto l165
 				}
 				depth--
-				add(ruleRefMerge, position164)
+				add(ruleRefMerge, position166)
 			}
 			return true
-		l163:
-			position, tokenIndex, depth = position163, tokenIndex163, depth163
+		l165:
+			position, tokenIndex, depth = position165, tokenIndex165, depth165
 			return false
 		},
 		/* 39 SimpleMerge <- <('m' 'e' 'r' 'g' 'e' (req_ws (Replace / Required / On))?)> */
 		func() bool {
-			position170, tokenIndex170, depth170 := position, tokenIndex, depth
+			position172, tokenIndex172, depth172 := position, tokenIndex, depth
 			{
-				position171 := position
+				position173 := position
 				depth++
 				if buffer[position] != rune('m') {
-					goto l170
+					goto l172
 				}
 				position++
 				if buffer[position] != rune('e') {
-					goto l170
+					goto l172
 				}
 				position++
 				if buffer[position] != rune('r') {
-					goto l170
+					goto l172
 				}
 				position++
 				if buffer[position] != rune('g') {
-					goto l170
+					goto l172
 				}
 				position++
 				if buffer[position] != rune('e') {
-					goto l170
+					goto l172
 				}
 				position++
 				{
-					position172, tokenIndex172, depth172 := position, tokenIndex, depth
+					position174, tokenIndex174, depth174 := position, tokenIndex, depth
 					if !_rules[rulereq_ws]() {
-						goto l172
+						goto l174
 					}
 					{
-						position174, tokenIndex174, depth174 := position, tokenIndex, depth
+						position176, tokenIndex176, depth176 := position, tokenIndex, depth
 						if !_rules[ruleReplace]() {
-							goto l175
+							goto l177
 						}
-						goto l174
-					l175:
-						position, tokenIndex, depth = position174, tokenIndex174, depth174
+						goto l176
+					l177:
+						position, tokenIndex, depth = position176, tokenIndex176, depth176
 						if !_rules[ruleRequired]() {
-							goto l176
+							goto l178
 						}
-						goto l174
-					l176:
-						position, tokenIndex, depth = position174, tokenIndex174, depth174
+						goto l176
+					l178:
+						position, tokenIndex, depth = position176, tokenIndex176, depth176
 						if !_rules[ruleOn]() {
-							goto l172
+							goto l174
 						}
 					}
+				l176:
+					goto l175
 				l174:
-					goto l173
-				l172:
-					position, tokenIndex, depth = position172, tokenIndex172, depth172
+					position, tokenIndex, depth = position174, tokenIndex174, depth174
 				}
-			l173:
+			l175:
 				depth--
-				add(ruleSimpleMerge, position171)
+				add(ruleSimpleMerge, position173)
 			}
 			return true
-		l170:
-			position, tokenIndex, depth = position170, tokenIndex170, depth170
+		l172:
+			position, tokenIndex, depth = position172, tokenIndex172, depth172
 			return false
 		},
 		/* 40 Replace <- <('r' 'e' 'p' 'l' 'a' 'c' 'e')> */
-		func() bool {
-			position177, tokenIndex177, depth177 := position, tokenIndex, depth
-			{
-				position178 := position
-				depth++
-				if buffer[position] != rune('r') {
-					goto l177
-				}
-				position++
-				if buffer[position] != rune('e') {
-					goto l177
-				}
-				position++
-				if buffer[position] != rune('p') {
-					goto l177
-				}
-				position++
-				if buffer[position] != rune('l') {
-					goto l177
-				}
-				position++
-				if buffer[position] != rune('a') {
-					goto l177
-				}
-				position++
-				if buffer[position] != rune('c') {
-					goto l177
-				}
-				position++
-				if buffer[position] != rune('e') {
-					goto l177
-				}
-				position++
-				depth--
-				add(ruleReplace, position178)
-			}
-			return true
-		l177:
-			position, tokenIndex, depth = position177, tokenIndex177, depth177
-			return false
-		},
-		/* 41 Required <- <('r' 'e' 'q' 'u' 'i' 'r' 'e' 'd')> */
 		func() bool {
 			position179, tokenIndex179, depth179 := position, tokenIndex, depth
 			{
@@ -2193,19 +2161,19 @@ func (p *DynamlGrammar) Init() {
 					goto l179
 				}
 				position++
-				if buffer[position] != rune('q') {
+				if buffer[position] != rune('p') {
 					goto l179
 				}
 				position++
-				if buffer[position] != rune('u') {
+				if buffer[position] != rune('l') {
 					goto l179
 				}
 				position++
-				if buffer[position] != rune('i') {
+				if buffer[position] != rune('a') {
 					goto l179
 				}
 				position++
-				if buffer[position] != rune('r') {
+				if buffer[position] != rune('c') {
 					goto l179
 				}
 				position++
@@ -2213,718 +2181,760 @@ func (p *DynamlGrammar) Init() {
 					goto l179
 				}
 				position++
-				if buffer[position] != rune('d') {
-					goto l179
-				}
-				position++
 				depth--
-				add(ruleRequired, position180)
+				add(ruleReplace, position180)
 			}
 			return true
 		l179:
 			position, tokenIndex, depth = position179, tokenIndex179, depth179
 			return false
 		},
-		/* 42 On <- <('o' 'n' req_ws Name)> */
+		/* 41 Required <- <('r' 'e' 'q' 'u' 'i' 'r' 'e' 'd')> */
 		func() bool {
 			position181, tokenIndex181, depth181 := position, tokenIndex, depth
 			{
 				position182 := position
 				depth++
-				if buffer[position] != rune('o') {
+				if buffer[position] != rune('r') {
 					goto l181
 				}
 				position++
-				if buffer[position] != rune('n') {
+				if buffer[position] != rune('e') {
 					goto l181
 				}
 				position++
-				if !_rules[rulereq_ws]() {
+				if buffer[position] != rune('q') {
 					goto l181
 				}
-				if !_rules[ruleName]() {
+				position++
+				if buffer[position] != rune('u') {
 					goto l181
 				}
+				position++
+				if buffer[position] != rune('i') {
+					goto l181
+				}
+				position++
+				if buffer[position] != rune('r') {
+					goto l181
+				}
+				position++
+				if buffer[position] != rune('e') {
+					goto l181
+				}
+				position++
+				if buffer[position] != rune('d') {
+					goto l181
+				}
+				position++
 				depth--
-				add(ruleOn, position182)
+				add(ruleRequired, position182)
 			}
 			return true
 		l181:
 			position, tokenIndex, depth = position181, tokenIndex181, depth181
 			return false
 		},
-		/* 43 Auto <- <('a' 'u' 't' 'o')> */
+		/* 42 On <- <('o' 'n' req_ws Name)> */
 		func() bool {
 			position183, tokenIndex183, depth183 := position, tokenIndex, depth
 			{
 				position184 := position
 				depth++
-				if buffer[position] != rune('a') {
-					goto l183
-				}
-				position++
-				if buffer[position] != rune('u') {
-					goto l183
-				}
-				position++
-				if buffer[position] != rune('t') {
-					goto l183
-				}
-				position++
 				if buffer[position] != rune('o') {
 					goto l183
 				}
 				position++
+				if buffer[position] != rune('n') {
+					goto l183
+				}
+				position++
+				if !_rules[rulereq_ws]() {
+					goto l183
+				}
+				if !_rules[ruleName]() {
+					goto l183
+				}
 				depth--
-				add(ruleAuto, position184)
+				add(ruleOn, position184)
 			}
 			return true
 		l183:
 			position, tokenIndex, depth = position183, tokenIndex183, depth183
 			return false
 		},
-		/* 44 Mapping <- <('m' 'a' 'p' '[' Expression (LambdaExpr / ('|' Expression)) ']')> */
+		/* 43 Auto <- <('a' 'u' 't' 'o')> */
 		func() bool {
 			position185, tokenIndex185, depth185 := position, tokenIndex, depth
 			{
 				position186 := position
 				depth++
-				if buffer[position] != rune('m') {
-					goto l185
-				}
-				position++
 				if buffer[position] != rune('a') {
 					goto l185
 				}
 				position++
-				if buffer[position] != rune('p') {
+				if buffer[position] != rune('u') {
 					goto l185
 				}
 				position++
-				if buffer[position] != rune('[') {
+				if buffer[position] != rune('t') {
 					goto l185
 				}
 				position++
-				if !_rules[ruleExpression]() {
-					goto l185
-				}
-				{
-					position187, tokenIndex187, depth187 := position, tokenIndex, depth
-					if !_rules[ruleLambdaExpr]() {
-						goto l188
-					}
-					goto l187
-				l188:
-					position, tokenIndex, depth = position187, tokenIndex187, depth187
-					if buffer[position] != rune('|') {
-						goto l185
-					}
-					position++
-					if !_rules[ruleExpression]() {
-						goto l185
-					}
-				}
-			l187:
-				if buffer[position] != rune(']') {
+				if buffer[position] != rune('o') {
 					goto l185
 				}
 				position++
 				depth--
-				add(ruleMapping, position186)
+				add(ruleAuto, position186)
 			}
 			return true
 		l185:
 			position, tokenIndex, depth = position185, tokenIndex185, depth185
 			return false
 		},
-		/* 45 Lambda <- <('l' 'a' 'm' 'b' 'd' 'a' (LambdaRef / LambdaExpr))> */
+		/* 44 Mapping <- <('m' 'a' 'p' '[' Level7 (LambdaExpr / ('|' Expression)) ']')> */
 		func() bool {
-			position189, tokenIndex189, depth189 := position, tokenIndex, depth
+			position187, tokenIndex187, depth187 := position, tokenIndex, depth
 			{
-				position190 := position
+				position188 := position
 				depth++
-				if buffer[position] != rune('l') {
-					goto l189
+				if buffer[position] != rune('m') {
+					goto l187
 				}
 				position++
 				if buffer[position] != rune('a') {
+					goto l187
+				}
+				position++
+				if buffer[position] != rune('p') {
+					goto l187
+				}
+				position++
+				if buffer[position] != rune('[') {
+					goto l187
+				}
+				position++
+				if !_rules[ruleLevel7]() {
+					goto l187
+				}
+				{
+					position189, tokenIndex189, depth189 := position, tokenIndex, depth
+					if !_rules[ruleLambdaExpr]() {
+						goto l190
+					}
 					goto l189
+				l190:
+					position, tokenIndex, depth = position189, tokenIndex189, depth189
+					if buffer[position] != rune('|') {
+						goto l187
+					}
+					position++
+					if !_rules[ruleExpression]() {
+						goto l187
+					}
+				}
+			l189:
+				if buffer[position] != rune(']') {
+					goto l187
+				}
+				position++
+				depth--
+				add(ruleMapping, position188)
+			}
+			return true
+		l187:
+			position, tokenIndex, depth = position187, tokenIndex187, depth187
+			return false
+		},
+		/* 45 Lambda <- <('l' 'a' 'm' 'b' 'd' 'a' (LambdaRef / LambdaExpr))> */
+		func() bool {
+			position191, tokenIndex191, depth191 := position, tokenIndex, depth
+			{
+				position192 := position
+				depth++
+				if buffer[position] != rune('l') {
+					goto l191
+				}
+				position++
+				if buffer[position] != rune('a') {
+					goto l191
 				}
 				position++
 				if buffer[position] != rune('m') {
-					goto l189
+					goto l191
 				}
 				position++
 				if buffer[position] != rune('b') {
-					goto l189
+					goto l191
 				}
 				position++
 				if buffer[position] != rune('d') {
-					goto l189
+					goto l191
 				}
 				position++
 				if buffer[position] != rune('a') {
-					goto l189
+					goto l191
 				}
 				position++
 				{
-					position191, tokenIndex191, depth191 := position, tokenIndex, depth
+					position193, tokenIndex193, depth193 := position, tokenIndex, depth
 					if !_rules[ruleLambdaRef]() {
-						goto l192
+						goto l194
 					}
-					goto l191
-				l192:
-					position, tokenIndex, depth = position191, tokenIndex191, depth191
+					goto l193
+				l194:
+					position, tokenIndex, depth = position193, tokenIndex193, depth193
 					if !_rules[ruleLambdaExpr]() {
-						goto l189
+						goto l191
 					}
 				}
-			l191:
+			l193:
 				depth--
-				add(ruleLambda, position190)
+				add(ruleLambda, position192)
 			}
 			return true
-		l189:
-			position, tokenIndex, depth = position189, tokenIndex189, depth189
+		l191:
+			position, tokenIndex, depth = position191, tokenIndex191, depth191
 			return false
 		},
 		/* 46 LambdaRef <- <(req_ws Expression)> */
-		func() bool {
-			position193, tokenIndex193, depth193 := position, tokenIndex, depth
-			{
-				position194 := position
-				depth++
-				if !_rules[rulereq_ws]() {
-					goto l193
-				}
-				if !_rules[ruleExpression]() {
-					goto l193
-				}
-				depth--
-				add(ruleLambdaRef, position194)
-			}
-			return true
-		l193:
-			position, tokenIndex, depth = position193, tokenIndex193, depth193
-			return false
-		},
-		/* 47 LambdaExpr <- <(ws '|' ws Name NextName* ws '|' ws ('-' '>') Expression)> */
 		func() bool {
 			position195, tokenIndex195, depth195 := position, tokenIndex, depth
 			{
 				position196 := position
 				depth++
-				if !_rules[rulews]() {
+				if !_rules[rulereq_ws]() {
 					goto l195
 				}
-				if buffer[position] != rune('|') {
-					goto l195
-				}
-				position++
-				if !_rules[rulews]() {
-					goto l195
-				}
-				if !_rules[ruleName]() {
-					goto l195
-				}
-			l197:
-				{
-					position198, tokenIndex198, depth198 := position, tokenIndex, depth
-					if !_rules[ruleNextName]() {
-						goto l198
-					}
-					goto l197
-				l198:
-					position, tokenIndex, depth = position198, tokenIndex198, depth198
-				}
-				if !_rules[rulews]() {
-					goto l195
-				}
-				if buffer[position] != rune('|') {
-					goto l195
-				}
-				position++
-				if !_rules[rulews]() {
-					goto l195
-				}
-				if buffer[position] != rune('-') {
-					goto l195
-				}
-				position++
-				if buffer[position] != rune('>') {
-					goto l195
-				}
-				position++
 				if !_rules[ruleExpression]() {
 					goto l195
 				}
 				depth--
-				add(ruleLambdaExpr, position196)
+				add(ruleLambdaRef, position196)
 			}
 			return true
 		l195:
 			position, tokenIndex, depth = position195, tokenIndex195, depth195
 			return false
 		},
-		/* 48 NextName <- <(ws ',' ws Name)> */
+		/* 47 LambdaExpr <- <(ws '|' ws Name NextName* ws '|' ws ('-' '>') Expression)> */
 		func() bool {
-			position199, tokenIndex199, depth199 := position, tokenIndex, depth
+			position197, tokenIndex197, depth197 := position, tokenIndex, depth
 			{
-				position200 := position
+				position198 := position
 				depth++
 				if !_rules[rulews]() {
-					goto l199
+					goto l197
 				}
-				if buffer[position] != rune(',') {
-					goto l199
+				if buffer[position] != rune('|') {
+					goto l197
 				}
 				position++
 				if !_rules[rulews]() {
-					goto l199
+					goto l197
 				}
 				if !_rules[ruleName]() {
+					goto l197
+				}
+			l199:
+				{
+					position200, tokenIndex200, depth200 := position, tokenIndex, depth
+					if !_rules[ruleNextName]() {
+						goto l200
+					}
 					goto l199
+				l200:
+					position, tokenIndex, depth = position200, tokenIndex200, depth200
+				}
+				if !_rules[rulews]() {
+					goto l197
+				}
+				if buffer[position] != rune('|') {
+					goto l197
+				}
+				position++
+				if !_rules[rulews]() {
+					goto l197
+				}
+				if buffer[position] != rune('-') {
+					goto l197
+				}
+				position++
+				if buffer[position] != rune('>') {
+					goto l197
+				}
+				position++
+				if !_rules[ruleExpression]() {
+					goto l197
 				}
 				depth--
-				add(ruleNextName, position200)
+				add(ruleLambdaExpr, position198)
 			}
 			return true
-		l199:
-			position, tokenIndex, depth = position199, tokenIndex199, depth199
+		l197:
+			position, tokenIndex, depth = position197, tokenIndex197, depth197
 			return false
 		},
-		/* 49 Reference <- <('.'? Key ('.' (Key / Index))*)> */
+		/* 48 NextName <- <(ws ',' ws Name)> */
 		func() bool {
 			position201, tokenIndex201, depth201 := position, tokenIndex, depth
 			{
 				position202 := position
 				depth++
-				{
-					position203, tokenIndex203, depth203 := position, tokenIndex, depth
-					if buffer[position] != rune('.') {
-						goto l203
-					}
-					position++
-					goto l204
-				l203:
-					position, tokenIndex, depth = position203, tokenIndex203, depth203
-				}
-			l204:
-				if !_rules[ruleKey]() {
+				if !_rules[rulews]() {
 					goto l201
 				}
-			l205:
-				{
-					position206, tokenIndex206, depth206 := position, tokenIndex, depth
-					if buffer[position] != rune('.') {
-						goto l206
-					}
-					position++
-					{
-						position207, tokenIndex207, depth207 := position, tokenIndex, depth
-						if !_rules[ruleKey]() {
-							goto l208
-						}
-						goto l207
-					l208:
-						position, tokenIndex, depth = position207, tokenIndex207, depth207
-						if !_rules[ruleIndex]() {
-							goto l206
-						}
-					}
-				l207:
-					goto l205
-				l206:
-					position, tokenIndex, depth = position206, tokenIndex206, depth206
+				if buffer[position] != rune(',') {
+					goto l201
+				}
+				position++
+				if !_rules[rulews]() {
+					goto l201
+				}
+				if !_rules[ruleName]() {
+					goto l201
 				}
 				depth--
-				add(ruleReference, position202)
+				add(ruleNextName, position202)
 			}
 			return true
 		l201:
 			position, tokenIndex, depth = position201, tokenIndex201, depth201
 			return false
 		},
-		/* 50 FollowUpRef <- <((Key / Index) ('.' (Key / Index))*)> */
+		/* 49 Reference <- <('.'? Key ('.' (Key / Index))*)> */
 		func() bool {
-			position209, tokenIndex209, depth209 := position, tokenIndex, depth
+			position203, tokenIndex203, depth203 := position, tokenIndex, depth
 			{
-				position210 := position
+				position204 := position
 				depth++
 				{
-					position211, tokenIndex211, depth211 := position, tokenIndex, depth
-					if !_rules[ruleKey]() {
-						goto l212
-					}
-					goto l211
-				l212:
-					position, tokenIndex, depth = position211, tokenIndex211, depth211
-					if !_rules[ruleIndex]() {
-						goto l209
-					}
-				}
-			l211:
-			l213:
-				{
-					position214, tokenIndex214, depth214 := position, tokenIndex, depth
+					position205, tokenIndex205, depth205 := position, tokenIndex, depth
 					if buffer[position] != rune('.') {
-						goto l214
+						goto l205
+					}
+					position++
+					goto l206
+				l205:
+					position, tokenIndex, depth = position205, tokenIndex205, depth205
+				}
+			l206:
+				if !_rules[ruleKey]() {
+					goto l203
+				}
+			l207:
+				{
+					position208, tokenIndex208, depth208 := position, tokenIndex, depth
+					if buffer[position] != rune('.') {
+						goto l208
 					}
 					position++
 					{
-						position215, tokenIndex215, depth215 := position, tokenIndex, depth
+						position209, tokenIndex209, depth209 := position, tokenIndex, depth
 						if !_rules[ruleKey]() {
-							goto l216
+							goto l210
 						}
-						goto l215
-					l216:
-						position, tokenIndex, depth = position215, tokenIndex215, depth215
+						goto l209
+					l210:
+						position, tokenIndex, depth = position209, tokenIndex209, depth209
 						if !_rules[ruleIndex]() {
-							goto l214
+							goto l208
 						}
 					}
-				l215:
-					goto l213
-				l214:
-					position, tokenIndex, depth = position214, tokenIndex214, depth214
+				l209:
+					goto l207
+				l208:
+					position, tokenIndex, depth = position208, tokenIndex208, depth208
 				}
 				depth--
-				add(ruleFollowUpRef, position210)
+				add(ruleReference, position204)
 			}
 			return true
-		l209:
-			position, tokenIndex, depth = position209, tokenIndex209, depth209
+		l203:
+			position, tokenIndex, depth = position203, tokenIndex203, depth203
+			return false
+		},
+		/* 50 FollowUpRef <- <((Key / Index) ('.' (Key / Index))*)> */
+		func() bool {
+			position211, tokenIndex211, depth211 := position, tokenIndex, depth
+			{
+				position212 := position
+				depth++
+				{
+					position213, tokenIndex213, depth213 := position, tokenIndex, depth
+					if !_rules[ruleKey]() {
+						goto l214
+					}
+					goto l213
+				l214:
+					position, tokenIndex, depth = position213, tokenIndex213, depth213
+					if !_rules[ruleIndex]() {
+						goto l211
+					}
+				}
+			l213:
+			l215:
+				{
+					position216, tokenIndex216, depth216 := position, tokenIndex, depth
+					if buffer[position] != rune('.') {
+						goto l216
+					}
+					position++
+					{
+						position217, tokenIndex217, depth217 := position, tokenIndex, depth
+						if !_rules[ruleKey]() {
+							goto l218
+						}
+						goto l217
+					l218:
+						position, tokenIndex, depth = position217, tokenIndex217, depth217
+						if !_rules[ruleIndex]() {
+							goto l216
+						}
+					}
+				l217:
+					goto l215
+				l216:
+					position, tokenIndex, depth = position216, tokenIndex216, depth216
+				}
+				depth--
+				add(ruleFollowUpRef, position212)
+			}
+			return true
+		l211:
+			position, tokenIndex, depth = position211, tokenIndex211, depth211
 			return false
 		},
 		/* 51 Key <- <(([a-z] / [A-Z] / [0-9] / '_') ([a-z] / [A-Z] / [0-9] / '_' / '-')* (':' ([a-z] / [A-Z] / [0-9] / '_') ([a-z] / [A-Z] / [0-9] / '_' / '-')*)?)> */
 		func() bool {
-			position217, tokenIndex217, depth217 := position, tokenIndex, depth
+			position219, tokenIndex219, depth219 := position, tokenIndex, depth
 			{
-				position218 := position
+				position220 := position
 				depth++
 				{
-					position219, tokenIndex219, depth219 := position, tokenIndex, depth
+					position221, tokenIndex221, depth221 := position, tokenIndex, depth
 					if c := buffer[position]; c < rune('a') || c > rune('z') {
-						goto l220
-					}
-					position++
-					goto l219
-				l220:
-					position, tokenIndex, depth = position219, tokenIndex219, depth219
-					if c := buffer[position]; c < rune('A') || c > rune('Z') {
-						goto l221
-					}
-					position++
-					goto l219
-				l221:
-					position, tokenIndex, depth = position219, tokenIndex219, depth219
-					if c := buffer[position]; c < rune('0') || c > rune('9') {
 						goto l222
 					}
 					position++
-					goto l219
+					goto l221
 				l222:
-					position, tokenIndex, depth = position219, tokenIndex219, depth219
+					position, tokenIndex, depth = position221, tokenIndex221, depth221
+					if c := buffer[position]; c < rune('A') || c > rune('Z') {
+						goto l223
+					}
+					position++
+					goto l221
+				l223:
+					position, tokenIndex, depth = position221, tokenIndex221, depth221
+					if c := buffer[position]; c < rune('0') || c > rune('9') {
+						goto l224
+					}
+					position++
+					goto l221
+				l224:
+					position, tokenIndex, depth = position221, tokenIndex221, depth221
 					if buffer[position] != rune('_') {
-						goto l217
+						goto l219
 					}
 					position++
 				}
-			l219:
-			l223:
+			l221:
+			l225:
 				{
-					position224, tokenIndex224, depth224 := position, tokenIndex, depth
+					position226, tokenIndex226, depth226 := position, tokenIndex, depth
 					{
-						position225, tokenIndex225, depth225 := position, tokenIndex, depth
+						position227, tokenIndex227, depth227 := position, tokenIndex, depth
 						if c := buffer[position]; c < rune('a') || c > rune('z') {
-							goto l226
-						}
-						position++
-						goto l225
-					l226:
-						position, tokenIndex, depth = position225, tokenIndex225, depth225
-						if c := buffer[position]; c < rune('A') || c > rune('Z') {
-							goto l227
-						}
-						position++
-						goto l225
-					l227:
-						position, tokenIndex, depth = position225, tokenIndex225, depth225
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
 							goto l228
 						}
 						position++
-						goto l225
+						goto l227
 					l228:
-						position, tokenIndex, depth = position225, tokenIndex225, depth225
-						if buffer[position] != rune('_') {
+						position, tokenIndex, depth = position227, tokenIndex227, depth227
+						if c := buffer[position]; c < rune('A') || c > rune('Z') {
 							goto l229
 						}
 						position++
-						goto l225
+						goto l227
 					l229:
-						position, tokenIndex, depth = position225, tokenIndex225, depth225
-						if buffer[position] != rune('-') {
-							goto l224
-						}
-						position++
-					}
-				l225:
-					goto l223
-				l224:
-					position, tokenIndex, depth = position224, tokenIndex224, depth224
-				}
-				{
-					position230, tokenIndex230, depth230 := position, tokenIndex, depth
-					if buffer[position] != rune(':') {
-						goto l230
-					}
-					position++
-					{
-						position232, tokenIndex232, depth232 := position, tokenIndex, depth
-						if c := buffer[position]; c < rune('a') || c > rune('z') {
-							goto l233
-						}
-						position++
-						goto l232
-					l233:
-						position, tokenIndex, depth = position232, tokenIndex232, depth232
-						if c := buffer[position]; c < rune('A') || c > rune('Z') {
-							goto l234
-						}
-						position++
-						goto l232
-					l234:
-						position, tokenIndex, depth = position232, tokenIndex232, depth232
+						position, tokenIndex, depth = position227, tokenIndex227, depth227
 						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l235
-						}
-						position++
-						goto l232
-					l235:
-						position, tokenIndex, depth = position232, tokenIndex232, depth232
-						if buffer[position] != rune('_') {
 							goto l230
 						}
 						position++
+						goto l227
+					l230:
+						position, tokenIndex, depth = position227, tokenIndex227, depth227
+						if buffer[position] != rune('_') {
+							goto l231
+						}
+						position++
+						goto l227
+					l231:
+						position, tokenIndex, depth = position227, tokenIndex227, depth227
+						if buffer[position] != rune('-') {
+							goto l226
+						}
+						position++
 					}
-				l232:
-				l236:
+				l227:
+					goto l225
+				l226:
+					position, tokenIndex, depth = position226, tokenIndex226, depth226
+				}
+				{
+					position232, tokenIndex232, depth232 := position, tokenIndex, depth
+					if buffer[position] != rune(':') {
+						goto l232
+					}
+					position++
 					{
-						position237, tokenIndex237, depth237 := position, tokenIndex, depth
+						position234, tokenIndex234, depth234 := position, tokenIndex, depth
+						if c := buffer[position]; c < rune('a') || c > rune('z') {
+							goto l235
+						}
+						position++
+						goto l234
+					l235:
+						position, tokenIndex, depth = position234, tokenIndex234, depth234
+						if c := buffer[position]; c < rune('A') || c > rune('Z') {
+							goto l236
+						}
+						position++
+						goto l234
+					l236:
+						position, tokenIndex, depth = position234, tokenIndex234, depth234
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l237
+						}
+						position++
+						goto l234
+					l237:
+						position, tokenIndex, depth = position234, tokenIndex234, depth234
+						if buffer[position] != rune('_') {
+							goto l232
+						}
+						position++
+					}
+				l234:
+				l238:
+					{
+						position239, tokenIndex239, depth239 := position, tokenIndex, depth
 						{
-							position238, tokenIndex238, depth238 := position, tokenIndex, depth
+							position240, tokenIndex240, depth240 := position, tokenIndex, depth
 							if c := buffer[position]; c < rune('a') || c > rune('z') {
-								goto l239
-							}
-							position++
-							goto l238
-						l239:
-							position, tokenIndex, depth = position238, tokenIndex238, depth238
-							if c := buffer[position]; c < rune('A') || c > rune('Z') {
-								goto l240
-							}
-							position++
-							goto l238
-						l240:
-							position, tokenIndex, depth = position238, tokenIndex238, depth238
-							if c := buffer[position]; c < rune('0') || c > rune('9') {
 								goto l241
 							}
 							position++
-							goto l238
+							goto l240
 						l241:
-							position, tokenIndex, depth = position238, tokenIndex238, depth238
-							if buffer[position] != rune('_') {
+							position, tokenIndex, depth = position240, tokenIndex240, depth240
+							if c := buffer[position]; c < rune('A') || c > rune('Z') {
 								goto l242
 							}
 							position++
-							goto l238
+							goto l240
 						l242:
-							position, tokenIndex, depth = position238, tokenIndex238, depth238
+							position, tokenIndex, depth = position240, tokenIndex240, depth240
+							if c := buffer[position]; c < rune('0') || c > rune('9') {
+								goto l243
+							}
+							position++
+							goto l240
+						l243:
+							position, tokenIndex, depth = position240, tokenIndex240, depth240
+							if buffer[position] != rune('_') {
+								goto l244
+							}
+							position++
+							goto l240
+						l244:
+							position, tokenIndex, depth = position240, tokenIndex240, depth240
 							if buffer[position] != rune('-') {
-								goto l237
+								goto l239
 							}
 							position++
 						}
-					l238:
-						goto l236
-					l237:
-						position, tokenIndex, depth = position237, tokenIndex237, depth237
+					l240:
+						goto l238
+					l239:
+						position, tokenIndex, depth = position239, tokenIndex239, depth239
 					}
-					goto l231
-				l230:
-					position, tokenIndex, depth = position230, tokenIndex230, depth230
+					goto l233
+				l232:
+					position, tokenIndex, depth = position232, tokenIndex232, depth232
 				}
-			l231:
+			l233:
 				depth--
-				add(ruleKey, position218)
+				add(ruleKey, position220)
 			}
 			return true
-		l217:
-			position, tokenIndex, depth = position217, tokenIndex217, depth217
+		l219:
+			position, tokenIndex, depth = position219, tokenIndex219, depth219
 			return false
 		},
 		/* 52 Index <- <('[' [0-9]+ ']')> */
 		func() bool {
-			position243, tokenIndex243, depth243 := position, tokenIndex, depth
+			position245, tokenIndex245, depth245 := position, tokenIndex, depth
 			{
-				position244 := position
+				position246 := position
 				depth++
 				if buffer[position] != rune('[') {
-					goto l243
+					goto l245
 				}
 				position++
 				if c := buffer[position]; c < rune('0') || c > rune('9') {
-					goto l243
+					goto l245
 				}
 				position++
-			l245:
+			l247:
 				{
-					position246, tokenIndex246, depth246 := position, tokenIndex, depth
+					position248, tokenIndex248, depth248 := position, tokenIndex, depth
 					if c := buffer[position]; c < rune('0') || c > rune('9') {
-						goto l246
+						goto l248
 					}
 					position++
-					goto l245
-				l246:
-					position, tokenIndex, depth = position246, tokenIndex246, depth246
+					goto l247
+				l248:
+					position, tokenIndex, depth = position248, tokenIndex248, depth248
 				}
 				if buffer[position] != rune(']') {
-					goto l243
+					goto l245
 				}
 				position++
 				depth--
-				add(ruleIndex, position244)
+				add(ruleIndex, position246)
 			}
 			return true
-		l243:
-			position, tokenIndex, depth = position243, tokenIndex243, depth243
+		l245:
+			position, tokenIndex, depth = position245, tokenIndex245, depth245
 			return false
 		},
 		/* 53 ws <- <(' ' / '\t' / '\n' / '\r')*> */
 		func() bool {
 			{
-				position248 := position
+				position250 := position
 				depth++
-			l249:
+			l251:
 				{
-					position250, tokenIndex250, depth250 := position, tokenIndex, depth
+					position252, tokenIndex252, depth252 := position, tokenIndex, depth
 					{
-						position251, tokenIndex251, depth251 := position, tokenIndex, depth
+						position253, tokenIndex253, depth253 := position, tokenIndex, depth
 						if buffer[position] != rune(' ') {
-							goto l252
-						}
-						position++
-						goto l251
-					l252:
-						position, tokenIndex, depth = position251, tokenIndex251, depth251
-						if buffer[position] != rune('\t') {
-							goto l253
-						}
-						position++
-						goto l251
-					l253:
-						position, tokenIndex, depth = position251, tokenIndex251, depth251
-						if buffer[position] != rune('\n') {
 							goto l254
 						}
 						position++
-						goto l251
+						goto l253
 					l254:
-						position, tokenIndex, depth = position251, tokenIndex251, depth251
+						position, tokenIndex, depth = position253, tokenIndex253, depth253
+						if buffer[position] != rune('\t') {
+							goto l255
+						}
+						position++
+						goto l253
+					l255:
+						position, tokenIndex, depth = position253, tokenIndex253, depth253
+						if buffer[position] != rune('\n') {
+							goto l256
+						}
+						position++
+						goto l253
+					l256:
+						position, tokenIndex, depth = position253, tokenIndex253, depth253
 						if buffer[position] != rune('\r') {
-							goto l250
+							goto l252
 						}
 						position++
 					}
-				l251:
-					goto l249
-				l250:
-					position, tokenIndex, depth = position250, tokenIndex250, depth250
+				l253:
+					goto l251
+				l252:
+					position, tokenIndex, depth = position252, tokenIndex252, depth252
 				}
 				depth--
-				add(rulews, position248)
+				add(rulews, position250)
 			}
 			return true
 		},
 		/* 54 req_ws <- <(' ' / '\t' / '\n' / '\r')+> */
 		func() bool {
-			position255, tokenIndex255, depth255 := position, tokenIndex, depth
+			position257, tokenIndex257, depth257 := position, tokenIndex, depth
 			{
-				position256 := position
+				position258 := position
 				depth++
 				{
-					position259, tokenIndex259, depth259 := position, tokenIndex, depth
+					position261, tokenIndex261, depth261 := position, tokenIndex, depth
 					if buffer[position] != rune(' ') {
-						goto l260
-					}
-					position++
-					goto l259
-				l260:
-					position, tokenIndex, depth = position259, tokenIndex259, depth259
-					if buffer[position] != rune('\t') {
-						goto l261
-					}
-					position++
-					goto l259
-				l261:
-					position, tokenIndex, depth = position259, tokenIndex259, depth259
-					if buffer[position] != rune('\n') {
 						goto l262
 					}
 					position++
-					goto l259
+					goto l261
 				l262:
-					position, tokenIndex, depth = position259, tokenIndex259, depth259
+					position, tokenIndex, depth = position261, tokenIndex261, depth261
+					if buffer[position] != rune('\t') {
+						goto l263
+					}
+					position++
+					goto l261
+				l263:
+					position, tokenIndex, depth = position261, tokenIndex261, depth261
+					if buffer[position] != rune('\n') {
+						goto l264
+					}
+					position++
+					goto l261
+				l264:
+					position, tokenIndex, depth = position261, tokenIndex261, depth261
 					if buffer[position] != rune('\r') {
-						goto l255
+						goto l257
 					}
 					position++
 				}
+			l261:
 			l259:
-			l257:
 				{
-					position258, tokenIndex258, depth258 := position, tokenIndex, depth
+					position260, tokenIndex260, depth260 := position, tokenIndex, depth
 					{
-						position263, tokenIndex263, depth263 := position, tokenIndex, depth
+						position265, tokenIndex265, depth265 := position, tokenIndex, depth
 						if buffer[position] != rune(' ') {
-							goto l264
-						}
-						position++
-						goto l263
-					l264:
-						position, tokenIndex, depth = position263, tokenIndex263, depth263
-						if buffer[position] != rune('\t') {
-							goto l265
-						}
-						position++
-						goto l263
-					l265:
-						position, tokenIndex, depth = position263, tokenIndex263, depth263
-						if buffer[position] != rune('\n') {
 							goto l266
 						}
 						position++
-						goto l263
+						goto l265
 					l266:
-						position, tokenIndex, depth = position263, tokenIndex263, depth263
+						position, tokenIndex, depth = position265, tokenIndex265, depth265
+						if buffer[position] != rune('\t') {
+							goto l267
+						}
+						position++
+						goto l265
+					l267:
+						position, tokenIndex, depth = position265, tokenIndex265, depth265
+						if buffer[position] != rune('\n') {
+							goto l268
+						}
+						position++
+						goto l265
+					l268:
+						position, tokenIndex, depth = position265, tokenIndex265, depth265
 						if buffer[position] != rune('\r') {
-							goto l258
+							goto l260
 						}
 						position++
 					}
-				l263:
-					goto l257
-				l258:
-					position, tokenIndex, depth = position258, tokenIndex258, depth258
+				l265:
+					goto l259
+				l260:
+					position, tokenIndex, depth = position260, tokenIndex260, depth260
 				}
 				depth--
-				add(rulereq_ws, position256)
+				add(rulereq_ws, position258)
 			}
 			return true
-		l255:
-			position, tokenIndex, depth = position255, tokenIndex255, depth255
+		l257:
+			position, tokenIndex, depth = position257, tokenIndex257, depth257
 			return false
 		},
 	}

--- a/dynaml/dynaml.peg.go
+++ b/dynaml/dynaml.peg.go
@@ -1831,7 +1831,7 @@ func (p *DynamlGrammar) Init() {
 			position, tokenIndex, depth = position139, tokenIndex139, depth139
 			return false
 		},
-		/* 33 Mapping <- <('m' 'a' 'p' '[' Expression '|' ws Name NextName? ws '|' ws ('-' '>') Expression ']')> */
+		/* 33 Mapping <- <('m' 'a' 'p' '[' Expression (LambdaExpr / ('|' Expression)) ']')> */
 		func() bool {
 			position141, tokenIndex141, depth141 := position, tokenIndex, depth
 			{
@@ -1856,47 +1856,23 @@ func (p *DynamlGrammar) Init() {
 				if !_rules[ruleExpression]() {
 					goto l141
 				}
-				if buffer[position] != rune('|') {
-					goto l141
-				}
-				position++
-				if !_rules[rulews]() {
-					goto l141
-				}
-				if !_rules[ruleName]() {
-					goto l141
-				}
 				{
 					position143, tokenIndex143, depth143 := position, tokenIndex, depth
-					if !_rules[ruleNextName]() {
-						goto l143
+					if !_rules[ruleLambdaExpr]() {
+						goto l144
 					}
-					goto l144
-				l143:
+					goto l143
+				l144:
 					position, tokenIndex, depth = position143, tokenIndex143, depth143
+					if buffer[position] != rune('|') {
+						goto l141
+					}
+					position++
+					if !_rules[ruleExpression]() {
+						goto l141
+					}
 				}
-			l144:
-				if !_rules[rulews]() {
-					goto l141
-				}
-				if buffer[position] != rune('|') {
-					goto l141
-				}
-				position++
-				if !_rules[rulews]() {
-					goto l141
-				}
-				if buffer[position] != rune('-') {
-					goto l141
-				}
-				position++
-				if buffer[position] != rune('>') {
-					goto l141
-				}
-				position++
-				if !_rules[ruleExpression]() {
-					goto l141
-				}
+			l143:
 				if buffer[position] != rune(']') {
 					goto l141
 				}

--- a/dynaml/dynaml.peg.go
+++ b/dynaml/dynaml.peg.go
@@ -17,10 +17,18 @@ const (
 	ruleDynaml
 	rulePrefer
 	ruleExpression
-	ruleLevel4
+	ruleLevel7
 	ruleOr
-	ruleLevel3
+	ruleLevel6
+	ruleConditional
+	ruleLevel5
 	ruleConcatenation
+	ruleLevel4
+	ruleLogOr
+	ruleLogAnd
+	ruleLevel3
+	ruleComparison
+	ruleCompareOp
 	ruleLevel2
 	ruleAddition
 	ruleSubtraction
@@ -29,7 +37,10 @@ const (
 	ruleDivision
 	ruleModulo
 	ruleLevel0
+	ruleQualifiedExpression
+	ruleNot
 	ruleGrouped
+	ruleRange
 	ruleCall
 	ruleName
 	ruleArguments
@@ -53,7 +64,9 @@ const (
 	ruleLambdaExpr
 	ruleNextName
 	ruleReference
+	ruleFollowUpRef
 	ruleKey
+	ruleIndex
 	rulews
 	rulereq_ws
 
@@ -67,10 +80,18 @@ var rul3s = [...]string{
 	"Dynaml",
 	"Prefer",
 	"Expression",
-	"Level4",
+	"Level7",
 	"Or",
-	"Level3",
+	"Level6",
+	"Conditional",
+	"Level5",
 	"Concatenation",
+	"Level4",
+	"LogOr",
+	"LogAnd",
+	"Level3",
+	"Comparison",
+	"CompareOp",
 	"Level2",
 	"Addition",
 	"Subtraction",
@@ -79,7 +100,10 @@ var rul3s = [...]string{
 	"Division",
 	"Modulo",
 	"Level0",
+	"QualifiedExpression",
+	"Not",
 	"Grouped",
+	"Range",
 	"Call",
 	"Name",
 	"Arguments",
@@ -103,7 +127,9 @@ var rul3s = [...]string{
 	"LambdaExpr",
 	"NextName",
 	"Reference",
+	"FollowUpRef",
 	"Key",
+	"Index",
 	"ws",
 	"req_ws",
 
@@ -424,7 +450,7 @@ func (t *tokens32) Expand(index int) tokenTree {
 type DynamlGrammar struct {
 	Buffer string
 	buffer []rune
-	rules  [43]func() bool
+	rules  [56]func() bool
 	Parse  func(rule ...int) error
 	Reset  func()
 	tokenTree
@@ -637,7 +663,7 @@ func (p *DynamlGrammar) Init() {
 			position, tokenIndex, depth = position5, tokenIndex5, depth5
 			return false
 		},
-		/* 2 Expression <- <(ws Level4 ws)> */
+		/* 2 Expression <- <(ws Level7 ws)> */
 		func() bool {
 			position7, tokenIndex7, depth7 := position, tokenIndex, depth
 			{
@@ -646,7 +672,7 @@ func (p *DynamlGrammar) Init() {
 				if !_rules[rulews]() {
 					goto l7
 				}
-				if !_rules[ruleLevel4]() {
+				if !_rules[ruleLevel7]() {
 					goto l7
 				}
 				if !_rules[rulews]() {
@@ -660,13 +686,13 @@ func (p *DynamlGrammar) Init() {
 			position, tokenIndex, depth = position7, tokenIndex7, depth7
 			return false
 		},
-		/* 3 Level4 <- <(Level3 (req_ws Or)*)> */
+		/* 3 Level7 <- <(Level6 (req_ws Or)*)> */
 		func() bool {
 			position9, tokenIndex9, depth9 := position, tokenIndex, depth
 			{
 				position10 := position
 				depth++
-				if !_rules[ruleLevel3]() {
+				if !_rules[ruleLevel6]() {
 					goto l9
 				}
 			l11:
@@ -683,14 +709,14 @@ func (p *DynamlGrammar) Init() {
 					position, tokenIndex, depth = position12, tokenIndex12, depth12
 				}
 				depth--
-				add(ruleLevel4, position10)
+				add(ruleLevel7, position10)
 			}
 			return true
 		l9:
 			position, tokenIndex, depth = position9, tokenIndex9, depth9
 			return false
 		},
-		/* 4 Or <- <('|' '|' req_ws Level3)> */
+		/* 4 Or <- <('|' '|' req_ws Level6)> */
 		func() bool {
 			position13, tokenIndex13, depth13 := position, tokenIndex, depth
 			{
@@ -707,7 +733,7 @@ func (p *DynamlGrammar) Init() {
 				if !_rules[rulereq_ws]() {
 					goto l13
 				}
-				if !_rules[ruleLevel3]() {
+				if !_rules[ruleLevel6]() {
 					goto l13
 				}
 				depth--
@@ -718,1697 +744,2187 @@ func (p *DynamlGrammar) Init() {
 			position, tokenIndex, depth = position13, tokenIndex13, depth13
 			return false
 		},
-		/* 5 Level3 <- <(Level2 Concatenation*)> */
+		/* 5 Level6 <- <(Conditional / Level5)> */
 		func() bool {
 			position15, tokenIndex15, depth15 := position, tokenIndex, depth
 			{
 				position16 := position
 				depth++
-				if !_rules[ruleLevel2]() {
-					goto l15
-				}
-			l17:
 				{
-					position18, tokenIndex18, depth18 := position, tokenIndex, depth
-					if !_rules[ruleConcatenation]() {
+					position17, tokenIndex17, depth17 := position, tokenIndex, depth
+					if !_rules[ruleConditional]() {
 						goto l18
 					}
 					goto l17
 				l18:
-					position, tokenIndex, depth = position18, tokenIndex18, depth18
+					position, tokenIndex, depth = position17, tokenIndex17, depth17
+					if !_rules[ruleLevel5]() {
+						goto l15
+					}
 				}
+			l17:
 				depth--
-				add(ruleLevel3, position16)
+				add(ruleLevel6, position16)
 			}
 			return true
 		l15:
 			position, tokenIndex, depth = position15, tokenIndex15, depth15
 			return false
 		},
-		/* 6 Concatenation <- <(req_ws Level2)> */
+		/* 6 Conditional <- <(Level5 ws '?' Expression ':' Expression)> */
 		func() bool {
 			position19, tokenIndex19, depth19 := position, tokenIndex, depth
 			{
 				position20 := position
 				depth++
-				if !_rules[rulereq_ws]() {
+				if !_rules[ruleLevel5]() {
 					goto l19
 				}
-				if !_rules[ruleLevel2]() {
+				if !_rules[rulews]() {
+					goto l19
+				}
+				if buffer[position] != rune('?') {
+					goto l19
+				}
+				position++
+				if !_rules[ruleExpression]() {
+					goto l19
+				}
+				if buffer[position] != rune(':') {
+					goto l19
+				}
+				position++
+				if !_rules[ruleExpression]() {
 					goto l19
 				}
 				depth--
-				add(ruleConcatenation, position20)
+				add(ruleConditional, position20)
 			}
 			return true
 		l19:
 			position, tokenIndex, depth = position19, tokenIndex19, depth19
 			return false
 		},
-		/* 7 Level2 <- <(Level1 (req_ws (Addition / Subtraction))*)> */
+		/* 7 Level5 <- <(Level4 Concatenation*)> */
 		func() bool {
 			position21, tokenIndex21, depth21 := position, tokenIndex, depth
 			{
 				position22 := position
 				depth++
-				if !_rules[ruleLevel1]() {
+				if !_rules[ruleLevel4]() {
 					goto l21
 				}
 			l23:
 				{
 					position24, tokenIndex24, depth24 := position, tokenIndex, depth
-					if !_rules[rulereq_ws]() {
+					if !_rules[ruleConcatenation]() {
 						goto l24
 					}
-					{
-						position25, tokenIndex25, depth25 := position, tokenIndex, depth
-						if !_rules[ruleAddition]() {
-							goto l26
-						}
-						goto l25
-					l26:
-						position, tokenIndex, depth = position25, tokenIndex25, depth25
-						if !_rules[ruleSubtraction]() {
-							goto l24
-						}
-					}
-				l25:
 					goto l23
 				l24:
 					position, tokenIndex, depth = position24, tokenIndex24, depth24
 				}
 				depth--
-				add(ruleLevel2, position22)
+				add(ruleLevel5, position22)
 			}
 			return true
 		l21:
 			position, tokenIndex, depth = position21, tokenIndex21, depth21
 			return false
 		},
-		/* 8 Addition <- <('+' req_ws Level1)> */
+		/* 8 Concatenation <- <(req_ws Level4)> */
+		func() bool {
+			position25, tokenIndex25, depth25 := position, tokenIndex, depth
+			{
+				position26 := position
+				depth++
+				if !_rules[rulereq_ws]() {
+					goto l25
+				}
+				if !_rules[ruleLevel4]() {
+					goto l25
+				}
+				depth--
+				add(ruleConcatenation, position26)
+			}
+			return true
+		l25:
+			position, tokenIndex, depth = position25, tokenIndex25, depth25
+			return false
+		},
+		/* 9 Level4 <- <(Level3 (req_ws (LogOr / LogAnd))*)> */
 		func() bool {
 			position27, tokenIndex27, depth27 := position, tokenIndex, depth
 			{
 				position28 := position
 				depth++
-				if buffer[position] != rune('+') {
+				if !_rules[ruleLevel3]() {
 					goto l27
 				}
-				position++
-				if !_rules[rulereq_ws]() {
-					goto l27
-				}
-				if !_rules[ruleLevel1]() {
-					goto l27
+			l29:
+				{
+					position30, tokenIndex30, depth30 := position, tokenIndex, depth
+					if !_rules[rulereq_ws]() {
+						goto l30
+					}
+					{
+						position31, tokenIndex31, depth31 := position, tokenIndex, depth
+						if !_rules[ruleLogOr]() {
+							goto l32
+						}
+						goto l31
+					l32:
+						position, tokenIndex, depth = position31, tokenIndex31, depth31
+						if !_rules[ruleLogAnd]() {
+							goto l30
+						}
+					}
+				l31:
+					goto l29
+				l30:
+					position, tokenIndex, depth = position30, tokenIndex30, depth30
 				}
 				depth--
-				add(ruleAddition, position28)
+				add(ruleLevel4, position28)
 			}
 			return true
 		l27:
 			position, tokenIndex, depth = position27, tokenIndex27, depth27
 			return false
 		},
-		/* 9 Subtraction <- <('-' req_ws Level1)> */
+		/* 10 LogOr <- <('-' 'o' 'r' req_ws Level3)> */
 		func() bool {
-			position29, tokenIndex29, depth29 := position, tokenIndex, depth
+			position33, tokenIndex33, depth33 := position, tokenIndex, depth
 			{
-				position30 := position
+				position34 := position
 				depth++
 				if buffer[position] != rune('-') {
-					goto l29
-				}
-				position++
-				if !_rules[rulereq_ws]() {
-					goto l29
-				}
-				if !_rules[ruleLevel1]() {
-					goto l29
-				}
-				depth--
-				add(ruleSubtraction, position30)
-			}
-			return true
-		l29:
-			position, tokenIndex, depth = position29, tokenIndex29, depth29
-			return false
-		},
-		/* 10 Level1 <- <(Level0 (req_ws (Multiplication / Division / Modulo))*)> */
-		func() bool {
-			position31, tokenIndex31, depth31 := position, tokenIndex, depth
-			{
-				position32 := position
-				depth++
-				if !_rules[ruleLevel0]() {
-					goto l31
-				}
-			l33:
-				{
-					position34, tokenIndex34, depth34 := position, tokenIndex, depth
-					if !_rules[rulereq_ws]() {
-						goto l34
-					}
-					{
-						position35, tokenIndex35, depth35 := position, tokenIndex, depth
-						if !_rules[ruleMultiplication]() {
-							goto l36
-						}
-						goto l35
-					l36:
-						position, tokenIndex, depth = position35, tokenIndex35, depth35
-						if !_rules[ruleDivision]() {
-							goto l37
-						}
-						goto l35
-					l37:
-						position, tokenIndex, depth = position35, tokenIndex35, depth35
-						if !_rules[ruleModulo]() {
-							goto l34
-						}
-					}
-				l35:
 					goto l33
-				l34:
-					position, tokenIndex, depth = position34, tokenIndex34, depth34
 				}
-				depth--
-				add(ruleLevel1, position32)
-			}
-			return true
-		l31:
-			position, tokenIndex, depth = position31, tokenIndex31, depth31
-			return false
-		},
-		/* 11 Multiplication <- <('*' req_ws Level0)> */
-		func() bool {
-			position38, tokenIndex38, depth38 := position, tokenIndex, depth
-			{
-				position39 := position
-				depth++
-				if buffer[position] != rune('*') {
-					goto l38
+				position++
+				if buffer[position] != rune('o') {
+					goto l33
+				}
+				position++
+				if buffer[position] != rune('r') {
+					goto l33
 				}
 				position++
 				if !_rules[rulereq_ws]() {
-					goto l38
+					goto l33
 				}
-				if !_rules[ruleLevel0]() {
-					goto l38
+				if !_rules[ruleLevel3]() {
+					goto l33
 				}
 				depth--
-				add(ruleMultiplication, position39)
+				add(ruleLogOr, position34)
 			}
 			return true
-		l38:
-			position, tokenIndex, depth = position38, tokenIndex38, depth38
+		l33:
+			position, tokenIndex, depth = position33, tokenIndex33, depth33
 			return false
 		},
-		/* 12 Division <- <('/' req_ws Level0)> */
+		/* 11 LogAnd <- <('-' 'a' 'n' 'd' req_ws Level3)> */
 		func() bool {
-			position40, tokenIndex40, depth40 := position, tokenIndex, depth
+			position35, tokenIndex35, depth35 := position, tokenIndex, depth
 			{
-				position41 := position
+				position36 := position
 				depth++
-				if buffer[position] != rune('/') {
-					goto l40
+				if buffer[position] != rune('-') {
+					goto l35
+				}
+				position++
+				if buffer[position] != rune('a') {
+					goto l35
+				}
+				position++
+				if buffer[position] != rune('n') {
+					goto l35
+				}
+				position++
+				if buffer[position] != rune('d') {
+					goto l35
 				}
 				position++
 				if !_rules[rulereq_ws]() {
-					goto l40
+					goto l35
 				}
-				if !_rules[ruleLevel0]() {
-					goto l40
+				if !_rules[ruleLevel3]() {
+					goto l35
 				}
 				depth--
-				add(ruleDivision, position41)
+				add(ruleLogAnd, position36)
 			}
 			return true
-		l40:
-			position, tokenIndex, depth = position40, tokenIndex40, depth40
+		l35:
+			position, tokenIndex, depth = position35, tokenIndex35, depth35
 			return false
 		},
-		/* 13 Modulo <- <('%' req_ws Level0)> */
+		/* 12 Level3 <- <(Level2 (req_ws Comparison)*)> */
 		func() bool {
-			position42, tokenIndex42, depth42 := position, tokenIndex, depth
+			position37, tokenIndex37, depth37 := position, tokenIndex, depth
 			{
-				position43 := position
+				position38 := position
 				depth++
-				if buffer[position] != rune('%') {
-					goto l42
+				if !_rules[ruleLevel2]() {
+					goto l37
 				}
-				position++
-				if !_rules[rulereq_ws]() {
-					goto l42
-				}
-				if !_rules[ruleLevel0]() {
-					goto l42
+			l39:
+				{
+					position40, tokenIndex40, depth40 := position, tokenIndex, depth
+					if !_rules[rulereq_ws]() {
+						goto l40
+					}
+					if !_rules[ruleComparison]() {
+						goto l40
+					}
+					goto l39
+				l40:
+					position, tokenIndex, depth = position40, tokenIndex40, depth40
 				}
 				depth--
-				add(ruleModulo, position43)
+				add(ruleLevel3, position38)
 			}
 			return true
-		l42:
-			position, tokenIndex, depth = position42, tokenIndex42, depth42
+		l37:
+			position, tokenIndex, depth = position37, tokenIndex37, depth37
 			return false
 		},
-		/* 14 Level0 <- <(Call / Grouped / Boolean / Nil / String / Integer / List / Merge / Auto / Mapping / Lambda / Reference)> */
+		/* 13 Comparison <- <(CompareOp req_ws Level2)> */
 		func() bool {
-			position44, tokenIndex44, depth44 := position, tokenIndex, depth
+			position41, tokenIndex41, depth41 := position, tokenIndex, depth
 			{
-				position45 := position
+				position42 := position
+				depth++
+				if !_rules[ruleCompareOp]() {
+					goto l41
+				}
+				if !_rules[rulereq_ws]() {
+					goto l41
+				}
+				if !_rules[ruleLevel2]() {
+					goto l41
+				}
+				depth--
+				add(ruleComparison, position42)
+			}
+			return true
+		l41:
+			position, tokenIndex, depth = position41, tokenIndex41, depth41
+			return false
+		},
+		/* 14 CompareOp <- <(('=' '=') / ('!' '=') / ('<' '=') / ('>' '=') / '>' / '<' / '>')> */
+		func() bool {
+			position43, tokenIndex43, depth43 := position, tokenIndex, depth
+			{
+				position44 := position
 				depth++
 				{
-					position46, tokenIndex46, depth46 := position, tokenIndex, depth
-					if !_rules[ruleCall]() {
+					position45, tokenIndex45, depth45 := position, tokenIndex, depth
+					if buffer[position] != rune('=') {
+						goto l46
+					}
+					position++
+					if buffer[position] != rune('=') {
+						goto l46
+					}
+					position++
+					goto l45
+				l46:
+					position, tokenIndex, depth = position45, tokenIndex45, depth45
+					if buffer[position] != rune('!') {
 						goto l47
 					}
-					goto l46
+					position++
+					if buffer[position] != rune('=') {
+						goto l47
+					}
+					position++
+					goto l45
 				l47:
-					position, tokenIndex, depth = position46, tokenIndex46, depth46
-					if !_rules[ruleGrouped]() {
+					position, tokenIndex, depth = position45, tokenIndex45, depth45
+					if buffer[position] != rune('<') {
 						goto l48
 					}
-					goto l46
+					position++
+					if buffer[position] != rune('=') {
+						goto l48
+					}
+					position++
+					goto l45
 				l48:
-					position, tokenIndex, depth = position46, tokenIndex46, depth46
-					if !_rules[ruleBoolean]() {
+					position, tokenIndex, depth = position45, tokenIndex45, depth45
+					if buffer[position] != rune('>') {
 						goto l49
 					}
-					goto l46
+					position++
+					if buffer[position] != rune('=') {
+						goto l49
+					}
+					position++
+					goto l45
 				l49:
-					position, tokenIndex, depth = position46, tokenIndex46, depth46
-					if !_rules[ruleNil]() {
+					position, tokenIndex, depth = position45, tokenIndex45, depth45
+					if buffer[position] != rune('>') {
 						goto l50
 					}
-					goto l46
+					position++
+					goto l45
 				l50:
-					position, tokenIndex, depth = position46, tokenIndex46, depth46
-					if !_rules[ruleString]() {
+					position, tokenIndex, depth = position45, tokenIndex45, depth45
+					if buffer[position] != rune('<') {
 						goto l51
 					}
-					goto l46
+					position++
+					goto l45
 				l51:
-					position, tokenIndex, depth = position46, tokenIndex46, depth46
-					if !_rules[ruleInteger]() {
-						goto l52
+					position, tokenIndex, depth = position45, tokenIndex45, depth45
+					if buffer[position] != rune('>') {
+						goto l43
 					}
-					goto l46
-				l52:
-					position, tokenIndex, depth = position46, tokenIndex46, depth46
-					if !_rules[ruleList]() {
-						goto l53
-					}
-					goto l46
-				l53:
-					position, tokenIndex, depth = position46, tokenIndex46, depth46
-					if !_rules[ruleMerge]() {
-						goto l54
-					}
-					goto l46
-				l54:
-					position, tokenIndex, depth = position46, tokenIndex46, depth46
-					if !_rules[ruleAuto]() {
-						goto l55
-					}
-					goto l46
-				l55:
-					position, tokenIndex, depth = position46, tokenIndex46, depth46
-					if !_rules[ruleMapping]() {
-						goto l56
-					}
-					goto l46
-				l56:
-					position, tokenIndex, depth = position46, tokenIndex46, depth46
-					if !_rules[ruleLambda]() {
-						goto l57
-					}
-					goto l46
-				l57:
-					position, tokenIndex, depth = position46, tokenIndex46, depth46
-					if !_rules[ruleReference]() {
-						goto l44
-					}
+					position++
 				}
-			l46:
+			l45:
 				depth--
-				add(ruleLevel0, position45)
+				add(ruleCompareOp, position44)
 			}
 			return true
-		l44:
-			position, tokenIndex, depth = position44, tokenIndex44, depth44
+		l43:
+			position, tokenIndex, depth = position43, tokenIndex43, depth43
 			return false
 		},
-		/* 15 Grouped <- <('(' Expression ')')> */
+		/* 15 Level2 <- <(Level1 (req_ws (Addition / Subtraction))*)> */
+		func() bool {
+			position52, tokenIndex52, depth52 := position, tokenIndex, depth
+			{
+				position53 := position
+				depth++
+				if !_rules[ruleLevel1]() {
+					goto l52
+				}
+			l54:
+				{
+					position55, tokenIndex55, depth55 := position, tokenIndex, depth
+					if !_rules[rulereq_ws]() {
+						goto l55
+					}
+					{
+						position56, tokenIndex56, depth56 := position, tokenIndex, depth
+						if !_rules[ruleAddition]() {
+							goto l57
+						}
+						goto l56
+					l57:
+						position, tokenIndex, depth = position56, tokenIndex56, depth56
+						if !_rules[ruleSubtraction]() {
+							goto l55
+						}
+					}
+				l56:
+					goto l54
+				l55:
+					position, tokenIndex, depth = position55, tokenIndex55, depth55
+				}
+				depth--
+				add(ruleLevel2, position53)
+			}
+			return true
+		l52:
+			position, tokenIndex, depth = position52, tokenIndex52, depth52
+			return false
+		},
+		/* 16 Addition <- <('+' req_ws Level1)> */
 		func() bool {
 			position58, tokenIndex58, depth58 := position, tokenIndex, depth
 			{
 				position59 := position
 				depth++
-				if buffer[position] != rune('(') {
+				if buffer[position] != rune('+') {
 					goto l58
 				}
 				position++
-				if !_rules[ruleExpression]() {
+				if !_rules[rulereq_ws]() {
 					goto l58
 				}
-				if buffer[position] != rune(')') {
+				if !_rules[ruleLevel1]() {
 					goto l58
 				}
-				position++
 				depth--
-				add(ruleGrouped, position59)
+				add(ruleAddition, position59)
 			}
 			return true
 		l58:
 			position, tokenIndex, depth = position58, tokenIndex58, depth58
 			return false
 		},
-		/* 16 Call <- <((Reference / Grouped) '(' Arguments ')')> */
+		/* 17 Subtraction <- <('-' req_ws Level1)> */
 		func() bool {
 			position60, tokenIndex60, depth60 := position, tokenIndex, depth
 			{
 				position61 := position
 				depth++
-				{
-					position62, tokenIndex62, depth62 := position, tokenIndex, depth
-					if !_rules[ruleReference]() {
-						goto l63
-					}
-					goto l62
-				l63:
-					position, tokenIndex, depth = position62, tokenIndex62, depth62
-					if !_rules[ruleGrouped]() {
-						goto l60
-					}
-				}
-			l62:
-				if buffer[position] != rune('(') {
+				if buffer[position] != rune('-') {
 					goto l60
 				}
 				position++
-				if !_rules[ruleArguments]() {
+				if !_rules[rulereq_ws]() {
 					goto l60
 				}
-				if buffer[position] != rune(')') {
+				if !_rules[ruleLevel1]() {
 					goto l60
 				}
-				position++
 				depth--
-				add(ruleCall, position61)
+				add(ruleSubtraction, position61)
 			}
 			return true
 		l60:
 			position, tokenIndex, depth = position60, tokenIndex60, depth60
 			return false
 		},
-		/* 17 Name <- <([a-z] / [A-Z] / [0-9] / '_')+> */
+		/* 18 Level1 <- <(Level0 (req_ws (Multiplication / Division / Modulo))*)> */
 		func() bool {
-			position64, tokenIndex64, depth64 := position, tokenIndex, depth
+			position62, tokenIndex62, depth62 := position, tokenIndex, depth
 			{
-				position65 := position
+				position63 := position
 				depth++
-				{
-					position68, tokenIndex68, depth68 := position, tokenIndex, depth
-					if c := buffer[position]; c < rune('a') || c > rune('z') {
-						goto l69
-					}
-					position++
-					goto l68
-				l69:
-					position, tokenIndex, depth = position68, tokenIndex68, depth68
-					if c := buffer[position]; c < rune('A') || c > rune('Z') {
-						goto l70
-					}
-					position++
-					goto l68
-				l70:
-					position, tokenIndex, depth = position68, tokenIndex68, depth68
-					if c := buffer[position]; c < rune('0') || c > rune('9') {
-						goto l71
-					}
-					position++
-					goto l68
-				l71:
-					position, tokenIndex, depth = position68, tokenIndex68, depth68
-					if buffer[position] != rune('_') {
-						goto l64
-					}
-					position++
+				if !_rules[ruleLevel0]() {
+					goto l62
 				}
-			l68:
-			l66:
+			l64:
 				{
-					position67, tokenIndex67, depth67 := position, tokenIndex, depth
+					position65, tokenIndex65, depth65 := position, tokenIndex, depth
+					if !_rules[rulereq_ws]() {
+						goto l65
+					}
 					{
-						position72, tokenIndex72, depth72 := position, tokenIndex, depth
-						if c := buffer[position]; c < rune('a') || c > rune('z') {
-							goto l73
-						}
-						position++
-						goto l72
-					l73:
-						position, tokenIndex, depth = position72, tokenIndex72, depth72
-						if c := buffer[position]; c < rune('A') || c > rune('Z') {
-							goto l74
-						}
-						position++
-						goto l72
-					l74:
-						position, tokenIndex, depth = position72, tokenIndex72, depth72
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l75
-						}
-						position++
-						goto l72
-					l75:
-						position, tokenIndex, depth = position72, tokenIndex72, depth72
-						if buffer[position] != rune('_') {
+						position66, tokenIndex66, depth66 := position, tokenIndex, depth
+						if !_rules[ruleMultiplication]() {
 							goto l67
 						}
-						position++
+						goto l66
+					l67:
+						position, tokenIndex, depth = position66, tokenIndex66, depth66
+						if !_rules[ruleDivision]() {
+							goto l68
+						}
+						goto l66
+					l68:
+						position, tokenIndex, depth = position66, tokenIndex66, depth66
+						if !_rules[ruleModulo]() {
+							goto l65
+						}
 					}
-				l72:
-					goto l66
-				l67:
-					position, tokenIndex, depth = position67, tokenIndex67, depth67
+				l66:
+					goto l64
+				l65:
+					position, tokenIndex, depth = position65, tokenIndex65, depth65
 				}
 				depth--
-				add(ruleName, position65)
+				add(ruleLevel1, position63)
 			}
 			return true
-		l64:
-			position, tokenIndex, depth = position64, tokenIndex64, depth64
+		l62:
+			position, tokenIndex, depth = position62, tokenIndex62, depth62
 			return false
 		},
-		/* 18 Arguments <- <(Expression NextExpression*)> */
+		/* 19 Multiplication <- <('*' req_ws Level0)> */
 		func() bool {
-			position76, tokenIndex76, depth76 := position, tokenIndex, depth
+			position69, tokenIndex69, depth69 := position, tokenIndex, depth
 			{
-				position77 := position
+				position70 := position
 				depth++
-				if !_rules[ruleExpression]() {
-					goto l76
-				}
-			l78:
-				{
-					position79, tokenIndex79, depth79 := position, tokenIndex, depth
-					if !_rules[ruleNextExpression]() {
-						goto l79
-					}
-					goto l78
-				l79:
-					position, tokenIndex, depth = position79, tokenIndex79, depth79
-				}
-				depth--
-				add(ruleArguments, position77)
-			}
-			return true
-		l76:
-			position, tokenIndex, depth = position76, tokenIndex76, depth76
-			return false
-		},
-		/* 19 NextExpression <- <(',' Expression)> */
-		func() bool {
-			position80, tokenIndex80, depth80 := position, tokenIndex, depth
-			{
-				position81 := position
-				depth++
-				if buffer[position] != rune(',') {
-					goto l80
+				if buffer[position] != rune('*') {
+					goto l69
 				}
 				position++
-				if !_rules[ruleExpression]() {
-					goto l80
+				if !_rules[rulereq_ws]() {
+					goto l69
+				}
+				if !_rules[ruleLevel0]() {
+					goto l69
 				}
 				depth--
-				add(ruleNextExpression, position81)
+				add(ruleMultiplication, position70)
 			}
 			return true
-		l80:
-			position, tokenIndex, depth = position80, tokenIndex80, depth80
+		l69:
+			position, tokenIndex, depth = position69, tokenIndex69, depth69
 			return false
 		},
-		/* 20 Integer <- <('-'? ([0-9] / '_')+)> */
+		/* 20 Division <- <('/' req_ws Level0)> */
 		func() bool {
-			position82, tokenIndex82, depth82 := position, tokenIndex, depth
+			position71, tokenIndex71, depth71 := position, tokenIndex, depth
 			{
-				position83 := position
+				position72 := position
+				depth++
+				if buffer[position] != rune('/') {
+					goto l71
+				}
+				position++
+				if !_rules[rulereq_ws]() {
+					goto l71
+				}
+				if !_rules[ruleLevel0]() {
+					goto l71
+				}
+				depth--
+				add(ruleDivision, position72)
+			}
+			return true
+		l71:
+			position, tokenIndex, depth = position71, tokenIndex71, depth71
+			return false
+		},
+		/* 21 Modulo <- <('%' req_ws Level0)> */
+		func() bool {
+			position73, tokenIndex73, depth73 := position, tokenIndex, depth
+			{
+				position74 := position
+				depth++
+				if buffer[position] != rune('%') {
+					goto l73
+				}
+				position++
+				if !_rules[rulereq_ws]() {
+					goto l73
+				}
+				if !_rules[ruleLevel0]() {
+					goto l73
+				}
+				depth--
+				add(ruleModulo, position74)
+			}
+			return true
+		l73:
+			position, tokenIndex, depth = position73, tokenIndex73, depth73
+			return false
+		},
+		/* 22 Level0 <- <(QualifiedExpression / Not / Call / Grouped / Boolean / Nil / String / Integer / List / Range / Merge / Auto / Mapping / Lambda / Reference)> */
+		func() bool {
+			position75, tokenIndex75, depth75 := position, tokenIndex, depth
+			{
+				position76 := position
 				depth++
 				{
-					position84, tokenIndex84, depth84 := position, tokenIndex, depth
-					if buffer[position] != rune('-') {
-						goto l84
+					position77, tokenIndex77, depth77 := position, tokenIndex, depth
+					if !_rules[ruleQualifiedExpression]() {
+						goto l78
 					}
-					position++
-					goto l85
-				l84:
-					position, tokenIndex, depth = position84, tokenIndex84, depth84
-				}
-			l85:
-				{
-					position88, tokenIndex88, depth88 := position, tokenIndex, depth
-					if c := buffer[position]; c < rune('0') || c > rune('9') {
-						goto l89
+					goto l77
+				l78:
+					position, tokenIndex, depth = position77, tokenIndex77, depth77
+					if !_rules[ruleNot]() {
+						goto l79
 					}
-					position++
-					goto l88
-				l89:
-					position, tokenIndex, depth = position88, tokenIndex88, depth88
-					if buffer[position] != rune('_') {
+					goto l77
+				l79:
+					position, tokenIndex, depth = position77, tokenIndex77, depth77
+					if !_rules[ruleCall]() {
+						goto l80
+					}
+					goto l77
+				l80:
+					position, tokenIndex, depth = position77, tokenIndex77, depth77
+					if !_rules[ruleGrouped]() {
+						goto l81
+					}
+					goto l77
+				l81:
+					position, tokenIndex, depth = position77, tokenIndex77, depth77
+					if !_rules[ruleBoolean]() {
 						goto l82
 					}
-					position++
-				}
-			l88:
-			l86:
-				{
-					position87, tokenIndex87, depth87 := position, tokenIndex, depth
-					{
-						position90, tokenIndex90, depth90 := position, tokenIndex, depth
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l91
-						}
-						position++
-						goto l90
-					l91:
-						position, tokenIndex, depth = position90, tokenIndex90, depth90
-						if buffer[position] != rune('_') {
-							goto l87
-						}
-						position++
+					goto l77
+				l82:
+					position, tokenIndex, depth = position77, tokenIndex77, depth77
+					if !_rules[ruleNil]() {
+						goto l83
 					}
-				l90:
-					goto l86
+					goto l77
+				l83:
+					position, tokenIndex, depth = position77, tokenIndex77, depth77
+					if !_rules[ruleString]() {
+						goto l84
+					}
+					goto l77
+				l84:
+					position, tokenIndex, depth = position77, tokenIndex77, depth77
+					if !_rules[ruleInteger]() {
+						goto l85
+					}
+					goto l77
+				l85:
+					position, tokenIndex, depth = position77, tokenIndex77, depth77
+					if !_rules[ruleList]() {
+						goto l86
+					}
+					goto l77
+				l86:
+					position, tokenIndex, depth = position77, tokenIndex77, depth77
+					if !_rules[ruleRange]() {
+						goto l87
+					}
+					goto l77
 				l87:
-					position, tokenIndex, depth = position87, tokenIndex87, depth87
+					position, tokenIndex, depth = position77, tokenIndex77, depth77
+					if !_rules[ruleMerge]() {
+						goto l88
+					}
+					goto l77
+				l88:
+					position, tokenIndex, depth = position77, tokenIndex77, depth77
+					if !_rules[ruleAuto]() {
+						goto l89
+					}
+					goto l77
+				l89:
+					position, tokenIndex, depth = position77, tokenIndex77, depth77
+					if !_rules[ruleMapping]() {
+						goto l90
+					}
+					goto l77
+				l90:
+					position, tokenIndex, depth = position77, tokenIndex77, depth77
+					if !_rules[ruleLambda]() {
+						goto l91
+					}
+					goto l77
+				l91:
+					position, tokenIndex, depth = position77, tokenIndex77, depth77
+					if !_rules[ruleReference]() {
+						goto l75
+					}
 				}
+			l77:
 				depth--
-				add(ruleInteger, position83)
+				add(ruleLevel0, position76)
 			}
 			return true
-		l82:
-			position, tokenIndex, depth = position82, tokenIndex82, depth82
+		l75:
+			position, tokenIndex, depth = position75, tokenIndex75, depth75
 			return false
 		},
-		/* 21 String <- <('"' (('\\' '"') / (!'"' .))* '"')> */
+		/* 23 QualifiedExpression <- <((Call / Grouped / List / Range) '.' FollowUpRef)> */
 		func() bool {
 			position92, tokenIndex92, depth92 := position, tokenIndex, depth
 			{
 				position93 := position
 				depth++
-				if buffer[position] != rune('"') {
-					goto l92
-				}
-				position++
-			l94:
 				{
-					position95, tokenIndex95, depth95 := position, tokenIndex, depth
-					{
-						position96, tokenIndex96, depth96 := position, tokenIndex, depth
-						if buffer[position] != rune('\\') {
-							goto l97
-						}
-						position++
-						if buffer[position] != rune('"') {
-							goto l97
-						}
-						position++
-						goto l96
-					l97:
-						position, tokenIndex, depth = position96, tokenIndex96, depth96
-						{
-							position98, tokenIndex98, depth98 := position, tokenIndex, depth
-							if buffer[position] != rune('"') {
-								goto l98
-							}
-							position++
-							goto l95
-						l98:
-							position, tokenIndex, depth = position98, tokenIndex98, depth98
-						}
-						if !matchDot() {
-							goto l95
-						}
+					position94, tokenIndex94, depth94 := position, tokenIndex, depth
+					if !_rules[ruleCall]() {
+						goto l95
 					}
-				l96:
 					goto l94
 				l95:
-					position, tokenIndex, depth = position95, tokenIndex95, depth95
+					position, tokenIndex, depth = position94, tokenIndex94, depth94
+					if !_rules[ruleGrouped]() {
+						goto l96
+					}
+					goto l94
+				l96:
+					position, tokenIndex, depth = position94, tokenIndex94, depth94
+					if !_rules[ruleList]() {
+						goto l97
+					}
+					goto l94
+				l97:
+					position, tokenIndex, depth = position94, tokenIndex94, depth94
+					if !_rules[ruleRange]() {
+						goto l92
+					}
 				}
-				if buffer[position] != rune('"') {
+			l94:
+				if buffer[position] != rune('.') {
 					goto l92
 				}
 				position++
+				if !_rules[ruleFollowUpRef]() {
+					goto l92
+				}
 				depth--
-				add(ruleString, position93)
+				add(ruleQualifiedExpression, position93)
 			}
 			return true
 		l92:
 			position, tokenIndex, depth = position92, tokenIndex92, depth92
 			return false
 		},
-		/* 22 Boolean <- <(('t' 'r' 'u' 'e') / ('f' 'a' 'l' 's' 'e'))> */
+		/* 24 Not <- <('!' ws Level0)> */
 		func() bool {
-			position99, tokenIndex99, depth99 := position, tokenIndex, depth
+			position98, tokenIndex98, depth98 := position, tokenIndex, depth
 			{
-				position100 := position
+				position99 := position
 				depth++
-				{
-					position101, tokenIndex101, depth101 := position, tokenIndex, depth
-					if buffer[position] != rune('t') {
-						goto l102
-					}
-					position++
-					if buffer[position] != rune('r') {
-						goto l102
-					}
-					position++
-					if buffer[position] != rune('u') {
-						goto l102
-					}
-					position++
-					if buffer[position] != rune('e') {
-						goto l102
-					}
-					position++
-					goto l101
-				l102:
-					position, tokenIndex, depth = position101, tokenIndex101, depth101
-					if buffer[position] != rune('f') {
-						goto l99
-					}
-					position++
-					if buffer[position] != rune('a') {
-						goto l99
-					}
-					position++
-					if buffer[position] != rune('l') {
-						goto l99
-					}
-					position++
-					if buffer[position] != rune('s') {
-						goto l99
-					}
-					position++
-					if buffer[position] != rune('e') {
-						goto l99
-					}
-					position++
+				if buffer[position] != rune('!') {
+					goto l98
 				}
-			l101:
+				position++
+				if !_rules[rulews]() {
+					goto l98
+				}
+				if !_rules[ruleLevel0]() {
+					goto l98
+				}
 				depth--
-				add(ruleBoolean, position100)
+				add(ruleNot, position99)
 			}
 			return true
-		l99:
-			position, tokenIndex, depth = position99, tokenIndex99, depth99
+		l98:
+			position, tokenIndex, depth = position98, tokenIndex98, depth98
 			return false
 		},
-		/* 23 Nil <- <(('n' 'i' 'l') / '~')> */
+		/* 25 Grouped <- <('(' Expression ')')> */
 		func() bool {
-			position103, tokenIndex103, depth103 := position, tokenIndex, depth
+			position100, tokenIndex100, depth100 := position, tokenIndex, depth
 			{
-				position104 := position
+				position101 := position
 				depth++
-				{
-					position105, tokenIndex105, depth105 := position, tokenIndex, depth
-					if buffer[position] != rune('n') {
-						goto l106
-					}
-					position++
-					if buffer[position] != rune('i') {
-						goto l106
-					}
-					position++
-					if buffer[position] != rune('l') {
-						goto l106
-					}
-					position++
-					goto l105
-				l106:
-					position, tokenIndex, depth = position105, tokenIndex105, depth105
-					if buffer[position] != rune('~') {
-						goto l103
-					}
-					position++
+				if buffer[position] != rune('(') {
+					goto l100
 				}
-			l105:
+				position++
+				if !_rules[ruleExpression]() {
+					goto l100
+				}
+				if buffer[position] != rune(')') {
+					goto l100
+				}
+				position++
 				depth--
-				add(ruleNil, position104)
+				add(ruleGrouped, position101)
 			}
 			return true
-		l103:
-			position, tokenIndex, depth = position103, tokenIndex103, depth103
+		l100:
+			position, tokenIndex, depth = position100, tokenIndex100, depth100
 			return false
 		},
-		/* 24 List <- <('[' Contents? ']')> */
+		/* 26 Range <- <('[' Expression ('.' '.') Expression ']')> */
 		func() bool {
-			position107, tokenIndex107, depth107 := position, tokenIndex, depth
+			position102, tokenIndex102, depth102 := position, tokenIndex, depth
 			{
-				position108 := position
+				position103 := position
 				depth++
 				if buffer[position] != rune('[') {
-					goto l107
+					goto l102
 				}
 				position++
-				{
-					position109, tokenIndex109, depth109 := position, tokenIndex, depth
-					if !_rules[ruleContents]() {
-						goto l109
-					}
-					goto l110
-				l109:
-					position, tokenIndex, depth = position109, tokenIndex109, depth109
+				if !_rules[ruleExpression]() {
+					goto l102
 				}
-			l110:
+				if buffer[position] != rune('.') {
+					goto l102
+				}
+				position++
+				if buffer[position] != rune('.') {
+					goto l102
+				}
+				position++
+				if !_rules[ruleExpression]() {
+					goto l102
+				}
 				if buffer[position] != rune(']') {
-					goto l107
+					goto l102
 				}
 				position++
 				depth--
-				add(ruleList, position108)
+				add(ruleRange, position103)
 			}
 			return true
-		l107:
-			position, tokenIndex, depth = position107, tokenIndex107, depth107
+		l102:
+			position, tokenIndex, depth = position102, tokenIndex102, depth102
 			return false
 		},
-		/* 25 Contents <- <(Expression NextExpression*)> */
+		/* 27 Call <- <((Reference / Grouped) '(' Arguments ')')> */
 		func() bool {
-			position111, tokenIndex111, depth111 := position, tokenIndex, depth
+			position104, tokenIndex104, depth104 := position, tokenIndex, depth
 			{
-				position112 := position
+				position105 := position
 				depth++
-				if !_rules[ruleExpression]() {
-					goto l111
-				}
-			l113:
 				{
-					position114, tokenIndex114, depth114 := position, tokenIndex, depth
-					if !_rules[ruleNextExpression]() {
+					position106, tokenIndex106, depth106 := position, tokenIndex, depth
+					if !_rules[ruleReference]() {
+						goto l107
+					}
+					goto l106
+				l107:
+					position, tokenIndex, depth = position106, tokenIndex106, depth106
+					if !_rules[ruleGrouped]() {
+						goto l104
+					}
+				}
+			l106:
+				if buffer[position] != rune('(') {
+					goto l104
+				}
+				position++
+				if !_rules[ruleArguments]() {
+					goto l104
+				}
+				if buffer[position] != rune(')') {
+					goto l104
+				}
+				position++
+				depth--
+				add(ruleCall, position105)
+			}
+			return true
+		l104:
+			position, tokenIndex, depth = position104, tokenIndex104, depth104
+			return false
+		},
+		/* 28 Name <- <([a-z] / [A-Z] / [0-9] / '_')+> */
+		func() bool {
+			position108, tokenIndex108, depth108 := position, tokenIndex, depth
+			{
+				position109 := position
+				depth++
+				{
+					position112, tokenIndex112, depth112 := position, tokenIndex, depth
+					if c := buffer[position]; c < rune('a') || c > rune('z') {
+						goto l113
+					}
+					position++
+					goto l112
+				l113:
+					position, tokenIndex, depth = position112, tokenIndex112, depth112
+					if c := buffer[position]; c < rune('A') || c > rune('Z') {
 						goto l114
 					}
-					goto l113
+					position++
+					goto l112
 				l114:
-					position, tokenIndex, depth = position114, tokenIndex114, depth114
-				}
-				depth--
-				add(ruleContents, position112)
-			}
-			return true
-		l111:
-			position, tokenIndex, depth = position111, tokenIndex111, depth111
-			return false
-		},
-		/* 26 Merge <- <(RefMerge / SimpleMerge)> */
-		func() bool {
-			position115, tokenIndex115, depth115 := position, tokenIndex, depth
-			{
-				position116 := position
-				depth++
-				{
-					position117, tokenIndex117, depth117 := position, tokenIndex, depth
-					if !_rules[ruleRefMerge]() {
-						goto l118
-					}
-					goto l117
-				l118:
-					position, tokenIndex, depth = position117, tokenIndex117, depth117
-					if !_rules[ruleSimpleMerge]() {
+					position, tokenIndex, depth = position112, tokenIndex112, depth112
+					if c := buffer[position]; c < rune('0') || c > rune('9') {
 						goto l115
 					}
+					position++
+					goto l112
+				l115:
+					position, tokenIndex, depth = position112, tokenIndex112, depth112
+					if buffer[position] != rune('_') {
+						goto l108
+					}
+					position++
 				}
-			l117:
-				depth--
-				add(ruleMerge, position116)
-			}
-			return true
-		l115:
-			position, tokenIndex, depth = position115, tokenIndex115, depth115
-			return false
-		},
-		/* 27 RefMerge <- <('m' 'e' 'r' 'g' 'e' !(req_ws Required) (req_ws (Replace / On))? req_ws Reference)> */
-		func() bool {
-			position119, tokenIndex119, depth119 := position, tokenIndex, depth
-			{
-				position120 := position
-				depth++
-				if buffer[position] != rune('m') {
-					goto l119
-				}
-				position++
-				if buffer[position] != rune('e') {
-					goto l119
-				}
-				position++
-				if buffer[position] != rune('r') {
-					goto l119
-				}
-				position++
-				if buffer[position] != rune('g') {
-					goto l119
-				}
-				position++
-				if buffer[position] != rune('e') {
-					goto l119
-				}
-				position++
+			l112:
+			l110:
 				{
-					position121, tokenIndex121, depth121 := position, tokenIndex, depth
-					if !_rules[rulereq_ws]() {
-						goto l121
-					}
-					if !_rules[ruleRequired]() {
-						goto l121
-					}
-					goto l119
-				l121:
-					position, tokenIndex, depth = position121, tokenIndex121, depth121
-				}
-				{
-					position122, tokenIndex122, depth122 := position, tokenIndex, depth
-					if !_rules[rulereq_ws]() {
-						goto l122
-					}
+					position111, tokenIndex111, depth111 := position, tokenIndex, depth
 					{
-						position124, tokenIndex124, depth124 := position, tokenIndex, depth
-						if !_rules[ruleReplace]() {
-							goto l125
+						position116, tokenIndex116, depth116 := position, tokenIndex, depth
+						if c := buffer[position]; c < rune('a') || c > rune('z') {
+							goto l117
 						}
-						goto l124
-					l125:
-						position, tokenIndex, depth = position124, tokenIndex124, depth124
-						if !_rules[ruleOn]() {
-							goto l122
+						position++
+						goto l116
+					l117:
+						position, tokenIndex, depth = position116, tokenIndex116, depth116
+						if c := buffer[position]; c < rune('A') || c > rune('Z') {
+							goto l118
 						}
+						position++
+						goto l116
+					l118:
+						position, tokenIndex, depth = position116, tokenIndex116, depth116
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l119
+						}
+						position++
+						goto l116
+					l119:
+						position, tokenIndex, depth = position116, tokenIndex116, depth116
+						if buffer[position] != rune('_') {
+							goto l111
+						}
+						position++
 					}
-				l124:
-					goto l123
-				l122:
-					position, tokenIndex, depth = position122, tokenIndex122, depth122
-				}
-			l123:
-				if !_rules[rulereq_ws]() {
-					goto l119
-				}
-				if !_rules[ruleReference]() {
-					goto l119
+				l116:
+					goto l110
+				l111:
+					position, tokenIndex, depth = position111, tokenIndex111, depth111
 				}
 				depth--
-				add(ruleRefMerge, position120)
+				add(ruleName, position109)
 			}
 			return true
-		l119:
-			position, tokenIndex, depth = position119, tokenIndex119, depth119
+		l108:
+			position, tokenIndex, depth = position108, tokenIndex108, depth108
 			return false
 		},
-		/* 28 SimpleMerge <- <('m' 'e' 'r' 'g' 'e' (req_ws (Replace / Required / On))?)> */
+		/* 29 Arguments <- <(Expression NextExpression*)> */
+		func() bool {
+			position120, tokenIndex120, depth120 := position, tokenIndex, depth
+			{
+				position121 := position
+				depth++
+				if !_rules[ruleExpression]() {
+					goto l120
+				}
+			l122:
+				{
+					position123, tokenIndex123, depth123 := position, tokenIndex, depth
+					if !_rules[ruleNextExpression]() {
+						goto l123
+					}
+					goto l122
+				l123:
+					position, tokenIndex, depth = position123, tokenIndex123, depth123
+				}
+				depth--
+				add(ruleArguments, position121)
+			}
+			return true
+		l120:
+			position, tokenIndex, depth = position120, tokenIndex120, depth120
+			return false
+		},
+		/* 30 NextExpression <- <(',' Expression)> */
+		func() bool {
+			position124, tokenIndex124, depth124 := position, tokenIndex, depth
+			{
+				position125 := position
+				depth++
+				if buffer[position] != rune(',') {
+					goto l124
+				}
+				position++
+				if !_rules[ruleExpression]() {
+					goto l124
+				}
+				depth--
+				add(ruleNextExpression, position125)
+			}
+			return true
+		l124:
+			position, tokenIndex, depth = position124, tokenIndex124, depth124
+			return false
+		},
+		/* 31 Integer <- <('-'? ([0-9] / '_')+)> */
 		func() bool {
 			position126, tokenIndex126, depth126 := position, tokenIndex, depth
 			{
 				position127 := position
 				depth++
-				if buffer[position] != rune('m') {
-					goto l126
-				}
-				position++
-				if buffer[position] != rune('e') {
-					goto l126
-				}
-				position++
-				if buffer[position] != rune('r') {
-					goto l126
-				}
-				position++
-				if buffer[position] != rune('g') {
-					goto l126
-				}
-				position++
-				if buffer[position] != rune('e') {
-					goto l126
-				}
-				position++
 				{
 					position128, tokenIndex128, depth128 := position, tokenIndex, depth
-					if !_rules[rulereq_ws]() {
+					if buffer[position] != rune('-') {
 						goto l128
 					}
-					{
-						position130, tokenIndex130, depth130 := position, tokenIndex, depth
-						if !_rules[ruleReplace]() {
-							goto l131
-						}
-						goto l130
-					l131:
-						position, tokenIndex, depth = position130, tokenIndex130, depth130
-						if !_rules[ruleRequired]() {
-							goto l132
-						}
-						goto l130
-					l132:
-						position, tokenIndex, depth = position130, tokenIndex130, depth130
-						if !_rules[ruleOn]() {
-							goto l128
-						}
-					}
-				l130:
+					position++
 					goto l129
 				l128:
 					position, tokenIndex, depth = position128, tokenIndex128, depth128
 				}
 			l129:
+				{
+					position132, tokenIndex132, depth132 := position, tokenIndex, depth
+					if c := buffer[position]; c < rune('0') || c > rune('9') {
+						goto l133
+					}
+					position++
+					goto l132
+				l133:
+					position, tokenIndex, depth = position132, tokenIndex132, depth132
+					if buffer[position] != rune('_') {
+						goto l126
+					}
+					position++
+				}
+			l132:
+			l130:
+				{
+					position131, tokenIndex131, depth131 := position, tokenIndex, depth
+					{
+						position134, tokenIndex134, depth134 := position, tokenIndex, depth
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l135
+						}
+						position++
+						goto l134
+					l135:
+						position, tokenIndex, depth = position134, tokenIndex134, depth134
+						if buffer[position] != rune('_') {
+							goto l131
+						}
+						position++
+					}
+				l134:
+					goto l130
+				l131:
+					position, tokenIndex, depth = position131, tokenIndex131, depth131
+				}
 				depth--
-				add(ruleSimpleMerge, position127)
+				add(ruleInteger, position127)
 			}
 			return true
 		l126:
 			position, tokenIndex, depth = position126, tokenIndex126, depth126
 			return false
 		},
-		/* 29 Replace <- <('r' 'e' 'p' 'l' 'a' 'c' 'e')> */
+		/* 32 String <- <('"' (('\\' '"') / (!'"' .))* '"')> */
 		func() bool {
-			position133, tokenIndex133, depth133 := position, tokenIndex, depth
+			position136, tokenIndex136, depth136 := position, tokenIndex, depth
 			{
-				position134 := position
+				position137 := position
 				depth++
-				if buffer[position] != rune('r') {
-					goto l133
+				if buffer[position] != rune('"') {
+					goto l136
 				}
 				position++
-				if buffer[position] != rune('e') {
-					goto l133
-				}
-				position++
-				if buffer[position] != rune('p') {
-					goto l133
-				}
-				position++
-				if buffer[position] != rune('l') {
-					goto l133
-				}
-				position++
-				if buffer[position] != rune('a') {
-					goto l133
-				}
-				position++
-				if buffer[position] != rune('c') {
-					goto l133
-				}
-				position++
-				if buffer[position] != rune('e') {
-					goto l133
-				}
-				position++
-				depth--
-				add(ruleReplace, position134)
-			}
-			return true
-		l133:
-			position, tokenIndex, depth = position133, tokenIndex133, depth133
-			return false
-		},
-		/* 30 Required <- <('r' 'e' 'q' 'u' 'i' 'r' 'e' 'd')> */
-		func() bool {
-			position135, tokenIndex135, depth135 := position, tokenIndex, depth
-			{
-				position136 := position
-				depth++
-				if buffer[position] != rune('r') {
-					goto l135
-				}
-				position++
-				if buffer[position] != rune('e') {
-					goto l135
-				}
-				position++
-				if buffer[position] != rune('q') {
-					goto l135
-				}
-				position++
-				if buffer[position] != rune('u') {
-					goto l135
-				}
-				position++
-				if buffer[position] != rune('i') {
-					goto l135
-				}
-				position++
-				if buffer[position] != rune('r') {
-					goto l135
-				}
-				position++
-				if buffer[position] != rune('e') {
-					goto l135
-				}
-				position++
-				if buffer[position] != rune('d') {
-					goto l135
-				}
-				position++
-				depth--
-				add(ruleRequired, position136)
-			}
-			return true
-		l135:
-			position, tokenIndex, depth = position135, tokenIndex135, depth135
-			return false
-		},
-		/* 31 On <- <('o' 'n' req_ws Name)> */
-		func() bool {
-			position137, tokenIndex137, depth137 := position, tokenIndex, depth
-			{
-				position138 := position
-				depth++
-				if buffer[position] != rune('o') {
-					goto l137
-				}
-				position++
-				if buffer[position] != rune('n') {
-					goto l137
-				}
-				position++
-				if !_rules[rulereq_ws]() {
-					goto l137
-				}
-				if !_rules[ruleName]() {
-					goto l137
-				}
-				depth--
-				add(ruleOn, position138)
-			}
-			return true
-		l137:
-			position, tokenIndex, depth = position137, tokenIndex137, depth137
-			return false
-		},
-		/* 32 Auto <- <('a' 'u' 't' 'o')> */
-		func() bool {
-			position139, tokenIndex139, depth139 := position, tokenIndex, depth
-			{
-				position140 := position
-				depth++
-				if buffer[position] != rune('a') {
-					goto l139
-				}
-				position++
-				if buffer[position] != rune('u') {
-					goto l139
-				}
-				position++
-				if buffer[position] != rune('t') {
-					goto l139
-				}
-				position++
-				if buffer[position] != rune('o') {
-					goto l139
-				}
-				position++
-				depth--
-				add(ruleAuto, position140)
-			}
-			return true
-		l139:
-			position, tokenIndex, depth = position139, tokenIndex139, depth139
-			return false
-		},
-		/* 33 Mapping <- <('m' 'a' 'p' '[' Expression (LambdaExpr / ('|' Expression)) ']')> */
-		func() bool {
-			position141, tokenIndex141, depth141 := position, tokenIndex, depth
-			{
-				position142 := position
-				depth++
-				if buffer[position] != rune('m') {
-					goto l141
-				}
-				position++
-				if buffer[position] != rune('a') {
-					goto l141
-				}
-				position++
-				if buffer[position] != rune('p') {
-					goto l141
-				}
-				position++
-				if buffer[position] != rune('[') {
-					goto l141
-				}
-				position++
-				if !_rules[ruleExpression]() {
-					goto l141
-				}
+			l138:
 				{
-					position143, tokenIndex143, depth143 := position, tokenIndex, depth
-					if !_rules[ruleLambdaExpr]() {
-						goto l144
+					position139, tokenIndex139, depth139 := position, tokenIndex, depth
+					{
+						position140, tokenIndex140, depth140 := position, tokenIndex, depth
+						if buffer[position] != rune('\\') {
+							goto l141
+						}
+						position++
+						if buffer[position] != rune('"') {
+							goto l141
+						}
+						position++
+						goto l140
+					l141:
+						position, tokenIndex, depth = position140, tokenIndex140, depth140
+						{
+							position142, tokenIndex142, depth142 := position, tokenIndex, depth
+							if buffer[position] != rune('"') {
+								goto l142
+							}
+							position++
+							goto l139
+						l142:
+							position, tokenIndex, depth = position142, tokenIndex142, depth142
+						}
+						if !matchDot() {
+							goto l139
+						}
 					}
-					goto l143
-				l144:
-					position, tokenIndex, depth = position143, tokenIndex143, depth143
-					if buffer[position] != rune('|') {
-						goto l141
+				l140:
+					goto l138
+				l139:
+					position, tokenIndex, depth = position139, tokenIndex139, depth139
+				}
+				if buffer[position] != rune('"') {
+					goto l136
+				}
+				position++
+				depth--
+				add(ruleString, position137)
+			}
+			return true
+		l136:
+			position, tokenIndex, depth = position136, tokenIndex136, depth136
+			return false
+		},
+		/* 33 Boolean <- <(('t' 'r' 'u' 'e') / ('f' 'a' 'l' 's' 'e'))> */
+		func() bool {
+			position143, tokenIndex143, depth143 := position, tokenIndex, depth
+			{
+				position144 := position
+				depth++
+				{
+					position145, tokenIndex145, depth145 := position, tokenIndex, depth
+					if buffer[position] != rune('t') {
+						goto l146
 					}
 					position++
-					if !_rules[ruleExpression]() {
-						goto l141
+					if buffer[position] != rune('r') {
+						goto l146
 					}
+					position++
+					if buffer[position] != rune('u') {
+						goto l146
+					}
+					position++
+					if buffer[position] != rune('e') {
+						goto l146
+					}
+					position++
+					goto l145
+				l146:
+					position, tokenIndex, depth = position145, tokenIndex145, depth145
+					if buffer[position] != rune('f') {
+						goto l143
+					}
+					position++
+					if buffer[position] != rune('a') {
+						goto l143
+					}
+					position++
+					if buffer[position] != rune('l') {
+						goto l143
+					}
+					position++
+					if buffer[position] != rune('s') {
+						goto l143
+					}
+					position++
+					if buffer[position] != rune('e') {
+						goto l143
+					}
+					position++
 				}
-			l143:
-				if buffer[position] != rune(']') {
-					goto l141
-				}
-				position++
+			l145:
 				depth--
-				add(ruleMapping, position142)
+				add(ruleBoolean, position144)
 			}
 			return true
-		l141:
-			position, tokenIndex, depth = position141, tokenIndex141, depth141
+		l143:
+			position, tokenIndex, depth = position143, tokenIndex143, depth143
 			return false
 		},
-		/* 34 Lambda <- <('l' 'a' 'm' 'b' 'd' 'a' (LambdaRef / LambdaExpr))> */
+		/* 34 Nil <- <(('n' 'i' 'l') / '~')> */
 		func() bool {
-			position145, tokenIndex145, depth145 := position, tokenIndex, depth
+			position147, tokenIndex147, depth147 := position, tokenIndex, depth
 			{
-				position146 := position
+				position148 := position
 				depth++
-				if buffer[position] != rune('l') {
-					goto l145
-				}
-				position++
-				if buffer[position] != rune('a') {
-					goto l145
-				}
-				position++
-				if buffer[position] != rune('m') {
-					goto l145
-				}
-				position++
-				if buffer[position] != rune('b') {
-					goto l145
-				}
-				position++
-				if buffer[position] != rune('d') {
-					goto l145
-				}
-				position++
-				if buffer[position] != rune('a') {
-					goto l145
-				}
-				position++
 				{
-					position147, tokenIndex147, depth147 := position, tokenIndex, depth
-					if !_rules[ruleLambdaRef]() {
-						goto l148
+					position149, tokenIndex149, depth149 := position, tokenIndex, depth
+					if buffer[position] != rune('n') {
+						goto l150
 					}
-					goto l147
-				l148:
-					position, tokenIndex, depth = position147, tokenIndex147, depth147
-					if !_rules[ruleLambdaExpr]() {
-						goto l145
+					position++
+					if buffer[position] != rune('i') {
+						goto l150
 					}
+					position++
+					if buffer[position] != rune('l') {
+						goto l150
+					}
+					position++
+					goto l149
+				l150:
+					position, tokenIndex, depth = position149, tokenIndex149, depth149
+					if buffer[position] != rune('~') {
+						goto l147
+					}
+					position++
 				}
-			l147:
+			l149:
 				depth--
-				add(ruleLambda, position146)
+				add(ruleNil, position148)
 			}
 			return true
-		l145:
-			position, tokenIndex, depth = position145, tokenIndex145, depth145
+		l147:
+			position, tokenIndex, depth = position147, tokenIndex147, depth147
 			return false
 		},
-		/* 35 LambdaRef <- <(req_ws Expression)> */
-		func() bool {
-			position149, tokenIndex149, depth149 := position, tokenIndex, depth
-			{
-				position150 := position
-				depth++
-				if !_rules[rulereq_ws]() {
-					goto l149
-				}
-				if !_rules[ruleExpression]() {
-					goto l149
-				}
-				depth--
-				add(ruleLambdaRef, position150)
-			}
-			return true
-		l149:
-			position, tokenIndex, depth = position149, tokenIndex149, depth149
-			return false
-		},
-		/* 36 LambdaExpr <- <(ws '|' ws Name NextName* ws '|' ws ('-' '>') Expression)> */
+		/* 35 List <- <('[' Contents? ']')> */
 		func() bool {
 			position151, tokenIndex151, depth151 := position, tokenIndex, depth
 			{
 				position152 := position
 				depth++
-				if !_rules[rulews]() {
-					goto l151
-				}
-				if buffer[position] != rune('|') {
+				if buffer[position] != rune('[') {
 					goto l151
 				}
 				position++
-				if !_rules[rulews]() {
-					goto l151
-				}
-				if !_rules[ruleName]() {
-					goto l151
-				}
-			l153:
 				{
-					position154, tokenIndex154, depth154 := position, tokenIndex, depth
-					if !_rules[ruleNextName]() {
-						goto l154
+					position153, tokenIndex153, depth153 := position, tokenIndex, depth
+					if !_rules[ruleContents]() {
+						goto l153
 					}
-					goto l153
-				l154:
-					position, tokenIndex, depth = position154, tokenIndex154, depth154
+					goto l154
+				l153:
+					position, tokenIndex, depth = position153, tokenIndex153, depth153
 				}
-				if !_rules[rulews]() {
-					goto l151
-				}
-				if buffer[position] != rune('|') {
-					goto l151
-				}
-				position++
-				if !_rules[rulews]() {
-					goto l151
-				}
-				if buffer[position] != rune('-') {
+			l154:
+				if buffer[position] != rune(']') {
 					goto l151
 				}
 				position++
-				if buffer[position] != rune('>') {
-					goto l151
-				}
-				position++
-				if !_rules[ruleExpression]() {
-					goto l151
-				}
 				depth--
-				add(ruleLambdaExpr, position152)
+				add(ruleList, position152)
 			}
 			return true
 		l151:
 			position, tokenIndex, depth = position151, tokenIndex151, depth151
 			return false
 		},
-		/* 37 NextName <- <(ws ',' ws Name)> */
+		/* 36 Contents <- <(Expression NextExpression*)> */
 		func() bool {
 			position155, tokenIndex155, depth155 := position, tokenIndex, depth
 			{
 				position156 := position
 				depth++
-				if !_rules[rulews]() {
+				if !_rules[ruleExpression]() {
 					goto l155
 				}
-				if buffer[position] != rune(',') {
-					goto l155
-				}
-				position++
-				if !_rules[rulews]() {
-					goto l155
-				}
-				if !_rules[ruleName]() {
-					goto l155
+			l157:
+				{
+					position158, tokenIndex158, depth158 := position, tokenIndex, depth
+					if !_rules[ruleNextExpression]() {
+						goto l158
+					}
+					goto l157
+				l158:
+					position, tokenIndex, depth = position158, tokenIndex158, depth158
 				}
 				depth--
-				add(ruleNextName, position156)
+				add(ruleContents, position156)
 			}
 			return true
 		l155:
 			position, tokenIndex, depth = position155, tokenIndex155, depth155
 			return false
 		},
-		/* 38 Reference <- <('.'? Key (('.' Key) / ('.' '[' [0-9]+ ']'))*)> */
+		/* 37 Merge <- <(RefMerge / SimpleMerge)> */
 		func() bool {
-			position157, tokenIndex157, depth157 := position, tokenIndex, depth
+			position159, tokenIndex159, depth159 := position, tokenIndex, depth
 			{
-				position158 := position
+				position160 := position
 				depth++
 				{
-					position159, tokenIndex159, depth159 := position, tokenIndex, depth
-					if buffer[position] != rune('.') {
-						goto l159
+					position161, tokenIndex161, depth161 := position, tokenIndex, depth
+					if !_rules[ruleRefMerge]() {
+						goto l162
 					}
-					position++
-					goto l160
-				l159:
-					position, tokenIndex, depth = position159, tokenIndex159, depth159
-				}
-			l160:
-				if !_rules[ruleKey]() {
-					goto l157
-				}
-			l161:
-				{
-					position162, tokenIndex162, depth162 := position, tokenIndex, depth
-					{
-						position163, tokenIndex163, depth163 := position, tokenIndex, depth
-						if buffer[position] != rune('.') {
-							goto l164
-						}
-						position++
-						if !_rules[ruleKey]() {
-							goto l164
-						}
-						goto l163
-					l164:
-						position, tokenIndex, depth = position163, tokenIndex163, depth163
-						if buffer[position] != rune('.') {
-							goto l162
-						}
-						position++
-						if buffer[position] != rune('[') {
-							goto l162
-						}
-						position++
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l162
-						}
-						position++
-					l165:
-						{
-							position166, tokenIndex166, depth166 := position, tokenIndex, depth
-							if c := buffer[position]; c < rune('0') || c > rune('9') {
-								goto l166
-							}
-							position++
-							goto l165
-						l166:
-							position, tokenIndex, depth = position166, tokenIndex166, depth166
-						}
-						if buffer[position] != rune(']') {
-							goto l162
-						}
-						position++
-					}
-				l163:
 					goto l161
 				l162:
-					position, tokenIndex, depth = position162, tokenIndex162, depth162
+					position, tokenIndex, depth = position161, tokenIndex161, depth161
+					if !_rules[ruleSimpleMerge]() {
+						goto l159
+					}
 				}
+			l161:
 				depth--
-				add(ruleReference, position158)
+				add(ruleMerge, position160)
 			}
 			return true
-		l157:
-			position, tokenIndex, depth = position157, tokenIndex157, depth157
+		l159:
+			position, tokenIndex, depth = position159, tokenIndex159, depth159
 			return false
 		},
-		/* 39 Key <- <(([a-z] / [A-Z] / [0-9] / '_') ([a-z] / [A-Z] / [0-9] / '_' / '-')* (':' ([a-z] / [A-Z] / [0-9] / '_') ([a-z] / [A-Z] / [0-9] / '_' / '-')*)?)> */
+		/* 38 RefMerge <- <('m' 'e' 'r' 'g' 'e' !(req_ws Required) (req_ws (Replace / On))? req_ws Reference)> */
 		func() bool {
-			position167, tokenIndex167, depth167 := position, tokenIndex, depth
+			position163, tokenIndex163, depth163 := position, tokenIndex, depth
 			{
-				position168 := position
+				position164 := position
 				depth++
+				if buffer[position] != rune('m') {
+					goto l163
+				}
+				position++
+				if buffer[position] != rune('e') {
+					goto l163
+				}
+				position++
+				if buffer[position] != rune('r') {
+					goto l163
+				}
+				position++
+				if buffer[position] != rune('g') {
+					goto l163
+				}
+				position++
+				if buffer[position] != rune('e') {
+					goto l163
+				}
+				position++
 				{
-					position169, tokenIndex169, depth169 := position, tokenIndex, depth
-					if c := buffer[position]; c < rune('a') || c > rune('z') {
-						goto l170
+					position165, tokenIndex165, depth165 := position, tokenIndex, depth
+					if !_rules[rulereq_ws]() {
+						goto l165
 					}
-					position++
-					goto l169
-				l170:
-					position, tokenIndex, depth = position169, tokenIndex169, depth169
-					if c := buffer[position]; c < rune('A') || c > rune('Z') {
-						goto l171
+					if !_rules[ruleRequired]() {
+						goto l165
 					}
-					position++
-					goto l169
-				l171:
-					position, tokenIndex, depth = position169, tokenIndex169, depth169
-					if c := buffer[position]; c < rune('0') || c > rune('9') {
+					goto l163
+				l165:
+					position, tokenIndex, depth = position165, tokenIndex165, depth165
+				}
+				{
+					position166, tokenIndex166, depth166 := position, tokenIndex, depth
+					if !_rules[rulereq_ws]() {
+						goto l166
+					}
+					{
+						position168, tokenIndex168, depth168 := position, tokenIndex, depth
+						if !_rules[ruleReplace]() {
+							goto l169
+						}
+						goto l168
+					l169:
+						position, tokenIndex, depth = position168, tokenIndex168, depth168
+						if !_rules[ruleOn]() {
+							goto l166
+						}
+					}
+				l168:
+					goto l167
+				l166:
+					position, tokenIndex, depth = position166, tokenIndex166, depth166
+				}
+			l167:
+				if !_rules[rulereq_ws]() {
+					goto l163
+				}
+				if !_rules[ruleReference]() {
+					goto l163
+				}
+				depth--
+				add(ruleRefMerge, position164)
+			}
+			return true
+		l163:
+			position, tokenIndex, depth = position163, tokenIndex163, depth163
+			return false
+		},
+		/* 39 SimpleMerge <- <('m' 'e' 'r' 'g' 'e' (req_ws (Replace / Required / On))?)> */
+		func() bool {
+			position170, tokenIndex170, depth170 := position, tokenIndex, depth
+			{
+				position171 := position
+				depth++
+				if buffer[position] != rune('m') {
+					goto l170
+				}
+				position++
+				if buffer[position] != rune('e') {
+					goto l170
+				}
+				position++
+				if buffer[position] != rune('r') {
+					goto l170
+				}
+				position++
+				if buffer[position] != rune('g') {
+					goto l170
+				}
+				position++
+				if buffer[position] != rune('e') {
+					goto l170
+				}
+				position++
+				{
+					position172, tokenIndex172, depth172 := position, tokenIndex, depth
+					if !_rules[rulereq_ws]() {
 						goto l172
 					}
-					position++
-					goto l169
-				l172:
-					position, tokenIndex, depth = position169, tokenIndex169, depth169
-					if buffer[position] != rune('_') {
-						goto l167
-					}
-					position++
-				}
-			l169:
-			l173:
-				{
-					position174, tokenIndex174, depth174 := position, tokenIndex, depth
 					{
-						position175, tokenIndex175, depth175 := position, tokenIndex, depth
-						if c := buffer[position]; c < rune('a') || c > rune('z') {
+						position174, tokenIndex174, depth174 := position, tokenIndex, depth
+						if !_rules[ruleReplace]() {
+							goto l175
+						}
+						goto l174
+					l175:
+						position, tokenIndex, depth = position174, tokenIndex174, depth174
+						if !_rules[ruleRequired]() {
 							goto l176
 						}
-						position++
-						goto l175
+						goto l174
 					l176:
-						position, tokenIndex, depth = position175, tokenIndex175, depth175
-						if c := buffer[position]; c < rune('A') || c > rune('Z') {
-							goto l177
+						position, tokenIndex, depth = position174, tokenIndex174, depth174
+						if !_rules[ruleOn]() {
+							goto l172
 						}
-						position++
-						goto l175
-					l177:
-						position, tokenIndex, depth = position175, tokenIndex175, depth175
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l178
-						}
-						position++
-						goto l175
-					l178:
-						position, tokenIndex, depth = position175, tokenIndex175, depth175
-						if buffer[position] != rune('_') {
-							goto l179
-						}
-						position++
-						goto l175
-					l179:
-						position, tokenIndex, depth = position175, tokenIndex175, depth175
-						if buffer[position] != rune('-') {
-							goto l174
-						}
-						position++
 					}
-				l175:
-					goto l173
 				l174:
-					position, tokenIndex, depth = position174, tokenIndex174, depth174
+					goto l173
+				l172:
+					position, tokenIndex, depth = position172, tokenIndex172, depth172
 				}
-				{
-					position180, tokenIndex180, depth180 := position, tokenIndex, depth
-					if buffer[position] != rune(':') {
-						goto l180
-					}
-					position++
-					{
-						position182, tokenIndex182, depth182 := position, tokenIndex, depth
-						if c := buffer[position]; c < rune('a') || c > rune('z') {
-							goto l183
-						}
-						position++
-						goto l182
-					l183:
-						position, tokenIndex, depth = position182, tokenIndex182, depth182
-						if c := buffer[position]; c < rune('A') || c > rune('Z') {
-							goto l184
-						}
-						position++
-						goto l182
-					l184:
-						position, tokenIndex, depth = position182, tokenIndex182, depth182
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l185
-						}
-						position++
-						goto l182
-					l185:
-						position, tokenIndex, depth = position182, tokenIndex182, depth182
-						if buffer[position] != rune('_') {
-							goto l180
-						}
-						position++
-					}
-				l182:
-				l186:
-					{
-						position187, tokenIndex187, depth187 := position, tokenIndex, depth
-						{
-							position188, tokenIndex188, depth188 := position, tokenIndex, depth
-							if c := buffer[position]; c < rune('a') || c > rune('z') {
-								goto l189
-							}
-							position++
-							goto l188
-						l189:
-							position, tokenIndex, depth = position188, tokenIndex188, depth188
-							if c := buffer[position]; c < rune('A') || c > rune('Z') {
-								goto l190
-							}
-							position++
-							goto l188
-						l190:
-							position, tokenIndex, depth = position188, tokenIndex188, depth188
-							if c := buffer[position]; c < rune('0') || c > rune('9') {
-								goto l191
-							}
-							position++
-							goto l188
-						l191:
-							position, tokenIndex, depth = position188, tokenIndex188, depth188
-							if buffer[position] != rune('_') {
-								goto l192
-							}
-							position++
-							goto l188
-						l192:
-							position, tokenIndex, depth = position188, tokenIndex188, depth188
-							if buffer[position] != rune('-') {
-								goto l187
-							}
-							position++
-						}
-					l188:
-						goto l186
-					l187:
-						position, tokenIndex, depth = position187, tokenIndex187, depth187
-					}
-					goto l181
-				l180:
-					position, tokenIndex, depth = position180, tokenIndex180, depth180
-				}
-			l181:
+			l173:
 				depth--
-				add(ruleKey, position168)
+				add(ruleSimpleMerge, position171)
 			}
 			return true
-		l167:
-			position, tokenIndex, depth = position167, tokenIndex167, depth167
+		l170:
+			position, tokenIndex, depth = position170, tokenIndex170, depth170
 			return false
 		},
-		/* 40 ws <- <(' ' / '\t' / '\n' / '\r')*> */
+		/* 40 Replace <- <('r' 'e' 'p' 'l' 'a' 'c' 'e')> */
 		func() bool {
+			position177, tokenIndex177, depth177 := position, tokenIndex, depth
+			{
+				position178 := position
+				depth++
+				if buffer[position] != rune('r') {
+					goto l177
+				}
+				position++
+				if buffer[position] != rune('e') {
+					goto l177
+				}
+				position++
+				if buffer[position] != rune('p') {
+					goto l177
+				}
+				position++
+				if buffer[position] != rune('l') {
+					goto l177
+				}
+				position++
+				if buffer[position] != rune('a') {
+					goto l177
+				}
+				position++
+				if buffer[position] != rune('c') {
+					goto l177
+				}
+				position++
+				if buffer[position] != rune('e') {
+					goto l177
+				}
+				position++
+				depth--
+				add(ruleReplace, position178)
+			}
+			return true
+		l177:
+			position, tokenIndex, depth = position177, tokenIndex177, depth177
+			return false
+		},
+		/* 41 Required <- <('r' 'e' 'q' 'u' 'i' 'r' 'e' 'd')> */
+		func() bool {
+			position179, tokenIndex179, depth179 := position, tokenIndex, depth
+			{
+				position180 := position
+				depth++
+				if buffer[position] != rune('r') {
+					goto l179
+				}
+				position++
+				if buffer[position] != rune('e') {
+					goto l179
+				}
+				position++
+				if buffer[position] != rune('q') {
+					goto l179
+				}
+				position++
+				if buffer[position] != rune('u') {
+					goto l179
+				}
+				position++
+				if buffer[position] != rune('i') {
+					goto l179
+				}
+				position++
+				if buffer[position] != rune('r') {
+					goto l179
+				}
+				position++
+				if buffer[position] != rune('e') {
+					goto l179
+				}
+				position++
+				if buffer[position] != rune('d') {
+					goto l179
+				}
+				position++
+				depth--
+				add(ruleRequired, position180)
+			}
+			return true
+		l179:
+			position, tokenIndex, depth = position179, tokenIndex179, depth179
+			return false
+		},
+		/* 42 On <- <('o' 'n' req_ws Name)> */
+		func() bool {
+			position181, tokenIndex181, depth181 := position, tokenIndex, depth
+			{
+				position182 := position
+				depth++
+				if buffer[position] != rune('o') {
+					goto l181
+				}
+				position++
+				if buffer[position] != rune('n') {
+					goto l181
+				}
+				position++
+				if !_rules[rulereq_ws]() {
+					goto l181
+				}
+				if !_rules[ruleName]() {
+					goto l181
+				}
+				depth--
+				add(ruleOn, position182)
+			}
+			return true
+		l181:
+			position, tokenIndex, depth = position181, tokenIndex181, depth181
+			return false
+		},
+		/* 43 Auto <- <('a' 'u' 't' 'o')> */
+		func() bool {
+			position183, tokenIndex183, depth183 := position, tokenIndex, depth
+			{
+				position184 := position
+				depth++
+				if buffer[position] != rune('a') {
+					goto l183
+				}
+				position++
+				if buffer[position] != rune('u') {
+					goto l183
+				}
+				position++
+				if buffer[position] != rune('t') {
+					goto l183
+				}
+				position++
+				if buffer[position] != rune('o') {
+					goto l183
+				}
+				position++
+				depth--
+				add(ruleAuto, position184)
+			}
+			return true
+		l183:
+			position, tokenIndex, depth = position183, tokenIndex183, depth183
+			return false
+		},
+		/* 44 Mapping <- <('m' 'a' 'p' '[' Expression (LambdaExpr / ('|' Expression)) ']')> */
+		func() bool {
+			position185, tokenIndex185, depth185 := position, tokenIndex, depth
+			{
+				position186 := position
+				depth++
+				if buffer[position] != rune('m') {
+					goto l185
+				}
+				position++
+				if buffer[position] != rune('a') {
+					goto l185
+				}
+				position++
+				if buffer[position] != rune('p') {
+					goto l185
+				}
+				position++
+				if buffer[position] != rune('[') {
+					goto l185
+				}
+				position++
+				if !_rules[ruleExpression]() {
+					goto l185
+				}
+				{
+					position187, tokenIndex187, depth187 := position, tokenIndex, depth
+					if !_rules[ruleLambdaExpr]() {
+						goto l188
+					}
+					goto l187
+				l188:
+					position, tokenIndex, depth = position187, tokenIndex187, depth187
+					if buffer[position] != rune('|') {
+						goto l185
+					}
+					position++
+					if !_rules[ruleExpression]() {
+						goto l185
+					}
+				}
+			l187:
+				if buffer[position] != rune(']') {
+					goto l185
+				}
+				position++
+				depth--
+				add(ruleMapping, position186)
+			}
+			return true
+		l185:
+			position, tokenIndex, depth = position185, tokenIndex185, depth185
+			return false
+		},
+		/* 45 Lambda <- <('l' 'a' 'm' 'b' 'd' 'a' (LambdaRef / LambdaExpr))> */
+		func() bool {
+			position189, tokenIndex189, depth189 := position, tokenIndex, depth
+			{
+				position190 := position
+				depth++
+				if buffer[position] != rune('l') {
+					goto l189
+				}
+				position++
+				if buffer[position] != rune('a') {
+					goto l189
+				}
+				position++
+				if buffer[position] != rune('m') {
+					goto l189
+				}
+				position++
+				if buffer[position] != rune('b') {
+					goto l189
+				}
+				position++
+				if buffer[position] != rune('d') {
+					goto l189
+				}
+				position++
+				if buffer[position] != rune('a') {
+					goto l189
+				}
+				position++
+				{
+					position191, tokenIndex191, depth191 := position, tokenIndex, depth
+					if !_rules[ruleLambdaRef]() {
+						goto l192
+					}
+					goto l191
+				l192:
+					position, tokenIndex, depth = position191, tokenIndex191, depth191
+					if !_rules[ruleLambdaExpr]() {
+						goto l189
+					}
+				}
+			l191:
+				depth--
+				add(ruleLambda, position190)
+			}
+			return true
+		l189:
+			position, tokenIndex, depth = position189, tokenIndex189, depth189
+			return false
+		},
+		/* 46 LambdaRef <- <(req_ws Expression)> */
+		func() bool {
+			position193, tokenIndex193, depth193 := position, tokenIndex, depth
 			{
 				position194 := position
 				depth++
-			l195:
-				{
-					position196, tokenIndex196, depth196 := position, tokenIndex, depth
-					{
-						position197, tokenIndex197, depth197 := position, tokenIndex, depth
-						if buffer[position] != rune(' ') {
-							goto l198
-						}
-						position++
-						goto l197
-					l198:
-						position, tokenIndex, depth = position197, tokenIndex197, depth197
-						if buffer[position] != rune('\t') {
-							goto l199
-						}
-						position++
-						goto l197
-					l199:
-						position, tokenIndex, depth = position197, tokenIndex197, depth197
-						if buffer[position] != rune('\n') {
-							goto l200
-						}
-						position++
-						goto l197
-					l200:
-						position, tokenIndex, depth = position197, tokenIndex197, depth197
-						if buffer[position] != rune('\r') {
-							goto l196
-						}
-						position++
-					}
-				l197:
-					goto l195
-				l196:
-					position, tokenIndex, depth = position196, tokenIndex196, depth196
+				if !_rules[rulereq_ws]() {
+					goto l193
+				}
+				if !_rules[ruleExpression]() {
+					goto l193
 				}
 				depth--
-				add(rulews, position194)
+				add(ruleLambdaRef, position194)
 			}
 			return true
+		l193:
+			position, tokenIndex, depth = position193, tokenIndex193, depth193
+			return false
 		},
-		/* 41 req_ws <- <(' ' / '\t' / '\n' / '\r')+> */
+		/* 47 LambdaExpr <- <(ws '|' ws Name NextName* ws '|' ws ('-' '>') Expression)> */
+		func() bool {
+			position195, tokenIndex195, depth195 := position, tokenIndex, depth
+			{
+				position196 := position
+				depth++
+				if !_rules[rulews]() {
+					goto l195
+				}
+				if buffer[position] != rune('|') {
+					goto l195
+				}
+				position++
+				if !_rules[rulews]() {
+					goto l195
+				}
+				if !_rules[ruleName]() {
+					goto l195
+				}
+			l197:
+				{
+					position198, tokenIndex198, depth198 := position, tokenIndex, depth
+					if !_rules[ruleNextName]() {
+						goto l198
+					}
+					goto l197
+				l198:
+					position, tokenIndex, depth = position198, tokenIndex198, depth198
+				}
+				if !_rules[rulews]() {
+					goto l195
+				}
+				if buffer[position] != rune('|') {
+					goto l195
+				}
+				position++
+				if !_rules[rulews]() {
+					goto l195
+				}
+				if buffer[position] != rune('-') {
+					goto l195
+				}
+				position++
+				if buffer[position] != rune('>') {
+					goto l195
+				}
+				position++
+				if !_rules[ruleExpression]() {
+					goto l195
+				}
+				depth--
+				add(ruleLambdaExpr, position196)
+			}
+			return true
+		l195:
+			position, tokenIndex, depth = position195, tokenIndex195, depth195
+			return false
+		},
+		/* 48 NextName <- <(ws ',' ws Name)> */
+		func() bool {
+			position199, tokenIndex199, depth199 := position, tokenIndex, depth
+			{
+				position200 := position
+				depth++
+				if !_rules[rulews]() {
+					goto l199
+				}
+				if buffer[position] != rune(',') {
+					goto l199
+				}
+				position++
+				if !_rules[rulews]() {
+					goto l199
+				}
+				if !_rules[ruleName]() {
+					goto l199
+				}
+				depth--
+				add(ruleNextName, position200)
+			}
+			return true
+		l199:
+			position, tokenIndex, depth = position199, tokenIndex199, depth199
+			return false
+		},
+		/* 49 Reference <- <('.'? Key ('.' (Key / Index))*)> */
 		func() bool {
 			position201, tokenIndex201, depth201 := position, tokenIndex, depth
 			{
 				position202 := position
 				depth++
 				{
-					position205, tokenIndex205, depth205 := position, tokenIndex, depth
-					if buffer[position] != rune(' ') {
+					position203, tokenIndex203, depth203 := position, tokenIndex, depth
+					if buffer[position] != rune('.') {
+						goto l203
+					}
+					position++
+					goto l204
+				l203:
+					position, tokenIndex, depth = position203, tokenIndex203, depth203
+				}
+			l204:
+				if !_rules[ruleKey]() {
+					goto l201
+				}
+			l205:
+				{
+					position206, tokenIndex206, depth206 := position, tokenIndex, depth
+					if buffer[position] != rune('.') {
 						goto l206
 					}
 					position++
+					{
+						position207, tokenIndex207, depth207 := position, tokenIndex, depth
+						if !_rules[ruleKey]() {
+							goto l208
+						}
+						goto l207
+					l208:
+						position, tokenIndex, depth = position207, tokenIndex207, depth207
+						if !_rules[ruleIndex]() {
+							goto l206
+						}
+					}
+				l207:
 					goto l205
 				l206:
-					position, tokenIndex, depth = position205, tokenIndex205, depth205
-					if buffer[position] != rune('\t') {
-						goto l207
-					}
-					position++
-					goto l205
-				l207:
-					position, tokenIndex, depth = position205, tokenIndex205, depth205
-					if buffer[position] != rune('\n') {
-						goto l208
-					}
-					position++
-					goto l205
-				l208:
-					position, tokenIndex, depth = position205, tokenIndex205, depth205
-					if buffer[position] != rune('\r') {
-						goto l201
-					}
-					position++
-				}
-			l205:
-			l203:
-				{
-					position204, tokenIndex204, depth204 := position, tokenIndex, depth
-					{
-						position209, tokenIndex209, depth209 := position, tokenIndex, depth
-						if buffer[position] != rune(' ') {
-							goto l210
-						}
-						position++
-						goto l209
-					l210:
-						position, tokenIndex, depth = position209, tokenIndex209, depth209
-						if buffer[position] != rune('\t') {
-							goto l211
-						}
-						position++
-						goto l209
-					l211:
-						position, tokenIndex, depth = position209, tokenIndex209, depth209
-						if buffer[position] != rune('\n') {
-							goto l212
-						}
-						position++
-						goto l209
-					l212:
-						position, tokenIndex, depth = position209, tokenIndex209, depth209
-						if buffer[position] != rune('\r') {
-							goto l204
-						}
-						position++
-					}
-				l209:
-					goto l203
-				l204:
-					position, tokenIndex, depth = position204, tokenIndex204, depth204
+					position, tokenIndex, depth = position206, tokenIndex206, depth206
 				}
 				depth--
-				add(rulereq_ws, position202)
+				add(ruleReference, position202)
 			}
 			return true
 		l201:
 			position, tokenIndex, depth = position201, tokenIndex201, depth201
+			return false
+		},
+		/* 50 FollowUpRef <- <((Key / Index) ('.' (Key / Index))*)> */
+		func() bool {
+			position209, tokenIndex209, depth209 := position, tokenIndex, depth
+			{
+				position210 := position
+				depth++
+				{
+					position211, tokenIndex211, depth211 := position, tokenIndex, depth
+					if !_rules[ruleKey]() {
+						goto l212
+					}
+					goto l211
+				l212:
+					position, tokenIndex, depth = position211, tokenIndex211, depth211
+					if !_rules[ruleIndex]() {
+						goto l209
+					}
+				}
+			l211:
+			l213:
+				{
+					position214, tokenIndex214, depth214 := position, tokenIndex, depth
+					if buffer[position] != rune('.') {
+						goto l214
+					}
+					position++
+					{
+						position215, tokenIndex215, depth215 := position, tokenIndex, depth
+						if !_rules[ruleKey]() {
+							goto l216
+						}
+						goto l215
+					l216:
+						position, tokenIndex, depth = position215, tokenIndex215, depth215
+						if !_rules[ruleIndex]() {
+							goto l214
+						}
+					}
+				l215:
+					goto l213
+				l214:
+					position, tokenIndex, depth = position214, tokenIndex214, depth214
+				}
+				depth--
+				add(ruleFollowUpRef, position210)
+			}
+			return true
+		l209:
+			position, tokenIndex, depth = position209, tokenIndex209, depth209
+			return false
+		},
+		/* 51 Key <- <(([a-z] / [A-Z] / [0-9] / '_') ([a-z] / [A-Z] / [0-9] / '_' / '-')* (':' ([a-z] / [A-Z] / [0-9] / '_') ([a-z] / [A-Z] / [0-9] / '_' / '-')*)?)> */
+		func() bool {
+			position217, tokenIndex217, depth217 := position, tokenIndex, depth
+			{
+				position218 := position
+				depth++
+				{
+					position219, tokenIndex219, depth219 := position, tokenIndex, depth
+					if c := buffer[position]; c < rune('a') || c > rune('z') {
+						goto l220
+					}
+					position++
+					goto l219
+				l220:
+					position, tokenIndex, depth = position219, tokenIndex219, depth219
+					if c := buffer[position]; c < rune('A') || c > rune('Z') {
+						goto l221
+					}
+					position++
+					goto l219
+				l221:
+					position, tokenIndex, depth = position219, tokenIndex219, depth219
+					if c := buffer[position]; c < rune('0') || c > rune('9') {
+						goto l222
+					}
+					position++
+					goto l219
+				l222:
+					position, tokenIndex, depth = position219, tokenIndex219, depth219
+					if buffer[position] != rune('_') {
+						goto l217
+					}
+					position++
+				}
+			l219:
+			l223:
+				{
+					position224, tokenIndex224, depth224 := position, tokenIndex, depth
+					{
+						position225, tokenIndex225, depth225 := position, tokenIndex, depth
+						if c := buffer[position]; c < rune('a') || c > rune('z') {
+							goto l226
+						}
+						position++
+						goto l225
+					l226:
+						position, tokenIndex, depth = position225, tokenIndex225, depth225
+						if c := buffer[position]; c < rune('A') || c > rune('Z') {
+							goto l227
+						}
+						position++
+						goto l225
+					l227:
+						position, tokenIndex, depth = position225, tokenIndex225, depth225
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l228
+						}
+						position++
+						goto l225
+					l228:
+						position, tokenIndex, depth = position225, tokenIndex225, depth225
+						if buffer[position] != rune('_') {
+							goto l229
+						}
+						position++
+						goto l225
+					l229:
+						position, tokenIndex, depth = position225, tokenIndex225, depth225
+						if buffer[position] != rune('-') {
+							goto l224
+						}
+						position++
+					}
+				l225:
+					goto l223
+				l224:
+					position, tokenIndex, depth = position224, tokenIndex224, depth224
+				}
+				{
+					position230, tokenIndex230, depth230 := position, tokenIndex, depth
+					if buffer[position] != rune(':') {
+						goto l230
+					}
+					position++
+					{
+						position232, tokenIndex232, depth232 := position, tokenIndex, depth
+						if c := buffer[position]; c < rune('a') || c > rune('z') {
+							goto l233
+						}
+						position++
+						goto l232
+					l233:
+						position, tokenIndex, depth = position232, tokenIndex232, depth232
+						if c := buffer[position]; c < rune('A') || c > rune('Z') {
+							goto l234
+						}
+						position++
+						goto l232
+					l234:
+						position, tokenIndex, depth = position232, tokenIndex232, depth232
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l235
+						}
+						position++
+						goto l232
+					l235:
+						position, tokenIndex, depth = position232, tokenIndex232, depth232
+						if buffer[position] != rune('_') {
+							goto l230
+						}
+						position++
+					}
+				l232:
+				l236:
+					{
+						position237, tokenIndex237, depth237 := position, tokenIndex, depth
+						{
+							position238, tokenIndex238, depth238 := position, tokenIndex, depth
+							if c := buffer[position]; c < rune('a') || c > rune('z') {
+								goto l239
+							}
+							position++
+							goto l238
+						l239:
+							position, tokenIndex, depth = position238, tokenIndex238, depth238
+							if c := buffer[position]; c < rune('A') || c > rune('Z') {
+								goto l240
+							}
+							position++
+							goto l238
+						l240:
+							position, tokenIndex, depth = position238, tokenIndex238, depth238
+							if c := buffer[position]; c < rune('0') || c > rune('9') {
+								goto l241
+							}
+							position++
+							goto l238
+						l241:
+							position, tokenIndex, depth = position238, tokenIndex238, depth238
+							if buffer[position] != rune('_') {
+								goto l242
+							}
+							position++
+							goto l238
+						l242:
+							position, tokenIndex, depth = position238, tokenIndex238, depth238
+							if buffer[position] != rune('-') {
+								goto l237
+							}
+							position++
+						}
+					l238:
+						goto l236
+					l237:
+						position, tokenIndex, depth = position237, tokenIndex237, depth237
+					}
+					goto l231
+				l230:
+					position, tokenIndex, depth = position230, tokenIndex230, depth230
+				}
+			l231:
+				depth--
+				add(ruleKey, position218)
+			}
+			return true
+		l217:
+			position, tokenIndex, depth = position217, tokenIndex217, depth217
+			return false
+		},
+		/* 52 Index <- <('[' [0-9]+ ']')> */
+		func() bool {
+			position243, tokenIndex243, depth243 := position, tokenIndex, depth
+			{
+				position244 := position
+				depth++
+				if buffer[position] != rune('[') {
+					goto l243
+				}
+				position++
+				if c := buffer[position]; c < rune('0') || c > rune('9') {
+					goto l243
+				}
+				position++
+			l245:
+				{
+					position246, tokenIndex246, depth246 := position, tokenIndex, depth
+					if c := buffer[position]; c < rune('0') || c > rune('9') {
+						goto l246
+					}
+					position++
+					goto l245
+				l246:
+					position, tokenIndex, depth = position246, tokenIndex246, depth246
+				}
+				if buffer[position] != rune(']') {
+					goto l243
+				}
+				position++
+				depth--
+				add(ruleIndex, position244)
+			}
+			return true
+		l243:
+			position, tokenIndex, depth = position243, tokenIndex243, depth243
+			return false
+		},
+		/* 53 ws <- <(' ' / '\t' / '\n' / '\r')*> */
+		func() bool {
+			{
+				position248 := position
+				depth++
+			l249:
+				{
+					position250, tokenIndex250, depth250 := position, tokenIndex, depth
+					{
+						position251, tokenIndex251, depth251 := position, tokenIndex, depth
+						if buffer[position] != rune(' ') {
+							goto l252
+						}
+						position++
+						goto l251
+					l252:
+						position, tokenIndex, depth = position251, tokenIndex251, depth251
+						if buffer[position] != rune('\t') {
+							goto l253
+						}
+						position++
+						goto l251
+					l253:
+						position, tokenIndex, depth = position251, tokenIndex251, depth251
+						if buffer[position] != rune('\n') {
+							goto l254
+						}
+						position++
+						goto l251
+					l254:
+						position, tokenIndex, depth = position251, tokenIndex251, depth251
+						if buffer[position] != rune('\r') {
+							goto l250
+						}
+						position++
+					}
+				l251:
+					goto l249
+				l250:
+					position, tokenIndex, depth = position250, tokenIndex250, depth250
+				}
+				depth--
+				add(rulews, position248)
+			}
+			return true
+		},
+		/* 54 req_ws <- <(' ' / '\t' / '\n' / '\r')+> */
+		func() bool {
+			position255, tokenIndex255, depth255 := position, tokenIndex, depth
+			{
+				position256 := position
+				depth++
+				{
+					position259, tokenIndex259, depth259 := position, tokenIndex, depth
+					if buffer[position] != rune(' ') {
+						goto l260
+					}
+					position++
+					goto l259
+				l260:
+					position, tokenIndex, depth = position259, tokenIndex259, depth259
+					if buffer[position] != rune('\t') {
+						goto l261
+					}
+					position++
+					goto l259
+				l261:
+					position, tokenIndex, depth = position259, tokenIndex259, depth259
+					if buffer[position] != rune('\n') {
+						goto l262
+					}
+					position++
+					goto l259
+				l262:
+					position, tokenIndex, depth = position259, tokenIndex259, depth259
+					if buffer[position] != rune('\r') {
+						goto l255
+					}
+					position++
+				}
+			l259:
+			l257:
+				{
+					position258, tokenIndex258, depth258 := position, tokenIndex, depth
+					{
+						position263, tokenIndex263, depth263 := position, tokenIndex, depth
+						if buffer[position] != rune(' ') {
+							goto l264
+						}
+						position++
+						goto l263
+					l264:
+						position, tokenIndex, depth = position263, tokenIndex263, depth263
+						if buffer[position] != rune('\t') {
+							goto l265
+						}
+						position++
+						goto l263
+					l265:
+						position, tokenIndex, depth = position263, tokenIndex263, depth263
+						if buffer[position] != rune('\n') {
+							goto l266
+						}
+						position++
+						goto l263
+					l266:
+						position, tokenIndex, depth = position263, tokenIndex263, depth263
+						if buffer[position] != rune('\r') {
+							goto l258
+						}
+						position++
+					}
+				l263:
+					goto l257
+				l258:
+					position, tokenIndex, depth = position258, tokenIndex258, depth258
+				}
+				depth--
+				add(rulereq_ws, position256)
+			}
+			return true
+		l255:
+			position, tokenIndex, depth = position255, tokenIndex255, depth255
 			return false
 		},
 	}

--- a/dynaml/env.go
+++ b/dynaml/env.go
@@ -1,0 +1,82 @@
+package dynaml
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+var environ []string = os.Environ()
+
+func ReloadEnv() {
+	environ = os.Environ()
+}
+
+func getenv(name string) (string, bool) {
+	name += "="
+	for _, s := range environ {
+		if strings.HasPrefix(s, name) {
+			return s[len(name):], true
+		}
+	}
+	return "", false
+}
+
+func func_env(arguments []interface{}, binding Binding) (interface{}, EvaluationInfo, bool) {
+	info := DefaultInfo()
+
+	if len(arguments) < 1 {
+		return nil, info, false
+	}
+
+	args := make([]string, 0)
+	for i, arg := range arguments {
+		switch v := arg.(type) {
+		case string:
+			args = append(args, v)
+		case int64:
+			args = append(args, strconv.FormatInt(v, 10))
+		case bool:
+			args = append(args, strconv.FormatBool(v))
+		case []yaml.Node:
+			for _, elem := range v {
+				switch e := elem.Value().(type) {
+				case string:
+					args = append(args, e)
+				case int64:
+					args = append(args, strconv.FormatInt(e, 10))
+				case bool:
+					args = append(args, strconv.FormatBool(e))
+				default:
+					info.Issue = yaml.NewIssue("elements of list(arg %d) to join must be simple values", i)
+					return nil, info, false
+				}
+			}
+		case nil:
+		default:
+			info.Issue = yaml.NewIssue("env argument %d must be simple value or list", i)
+			return nil, info, false
+		}
+	}
+
+	if len(args) == 1 {
+		s, ok := getenv(args[0])
+		if ok {
+			return s, info, ok
+		} else {
+			info.Issue = yaml.NewIssue("environment variable '%s' not set", args[0])
+			return nil, info, ok
+		}
+	} else {
+		m := make(map[string]yaml.Node)
+		for _, n := range args {
+			s, ok := getenv(n)
+			if ok {
+				m[n] = node(s, nil)
+			}
+		}
+		return m, info, true
+	}
+}

--- a/dynaml/error.go
+++ b/dynaml/error.go
@@ -1,0 +1,14 @@
+package dynaml
+
+import (
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+func func_error(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	n, info, ok := format("error", arguments, binding)
+	if !ok {
+		return n, info, ok
+	}
+	info.Issue = yaml.NewIssue("%s", n.Value())
+	return nil, info, false
+}

--- a/dynaml/error.go
+++ b/dynaml/error.go
@@ -4,11 +4,11 @@ import (
 	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
-func func_error(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func func_error(arguments []interface{}, binding Binding) (interface{}, EvaluationInfo, bool) {
 	n, info, ok := format("error", arguments, binding)
 	if !ok {
 		return n, info, ok
 	}
-	info.Issue = yaml.NewIssue("%s", n.Value())
+	info.Issue = yaml.NewIssue("%s", n)
 	return nil, info, false
 }

--- a/dynaml/eval.go
+++ b/dynaml/eval.go
@@ -4,7 +4,7 @@ import (
 	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
-func func_eval(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func func_eval(arguments []interface{}, binding Binding) (interface{}, EvaluationInfo, bool) {
 	info := DefaultInfo()
 
 	if len(arguments) != 1 {

--- a/dynaml/eval.go
+++ b/dynaml/eval.go
@@ -1,0 +1,27 @@
+package dynaml
+
+import (
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+func func_eval(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	info := DefaultInfo()
+
+	if len(arguments) != 1 {
+		info.Issue = yaml.NewIssue("one argument required for 'eval'")
+		return nil, info, false
+	}
+
+	str, ok := arguments[0].(string)
+	if !ok {
+		info.Issue = yaml.NewIssue("string argument required for 'eval'")
+		return nil, info, false
+	}
+
+	expr, err := Parse(str, binding.Path(), binding.StubPath())
+	if err != nil {
+		info.Issue = yaml.NewIssue("cannot parse expression '%s'", str)
+		return nil, info, false
+	}
+	return expr.Evaluate(binding)
+}

--- a/dynaml/evaluate_as_helper_test.go
+++ b/dynaml/evaluate_as_helper_test.go
@@ -2,18 +2,16 @@ package dynaml
 
 import (
 	"fmt"
-
-	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
 func EvaluateAs(expected interface{}, binding Binding) *EvaluateAsMatcher {
-	return &EvaluateAsMatcher{Expected: node(expected), Binding: binding}
+	return &EvaluateAsMatcher{Expected: expected, Binding: binding}
 }
 
 type EvaluateAsMatcher struct {
-	Expected yaml.Node
+	Expected interface{}
 	Binding  Binding
-	actual   yaml.Node
+	actual   interface{}
 }
 
 func (matcher *EvaluateAsMatcher) Match(source interface{}) (success bool, err error) {
@@ -27,11 +25,11 @@ func (matcher *EvaluateAsMatcher) Match(source interface{}) (success bool, err e
 	}
 
 	matcher.actual, _, ok = expr.Evaluate(matcher.Binding)
-	if matcher.actual == nil || !ok {
+	if !ok {
 		return false, fmt.Errorf("Node failed to evaluate.")
 	}
 
-	if matcher.actual.EquivalentToNode(matcher.Expected) {
+	if node(matcher.actual, nil).EquivalentToNode(node(matcher.Expected, nil)) {
 		return true, nil
 	} else {
 		return false, nil

--- a/dynaml/exec.go
+++ b/dynaml/exec.go
@@ -31,19 +31,19 @@ func func_exec(arguments []interface{}, binding Binding) (yaml.Node, EvaluationI
 				for j, arg := range list {
 					v, ok := getArg(j, arg.Value())
 					if !ok {
-						info.Issue = "command argument must be string"
+						info.Issue = yaml.NewIssue("command argument must be string")
 						return nil, info, false
 					}
 					args = append(args, v)
 				}
 			} else {
-				info.Issue = "list not allowed for command argument"
+				info.Issue = yaml.NewIssue("list not allowed for command argument")
 				return nil, info, false
 			}
 		} else {
 			v, ok := getArg(i, arg)
 			if !ok {
-				info.Issue = "command argument must be string"
+				info.Issue = yaml.NewIssue("command argument must be string")
 				return nil, info, false
 			}
 			args = append(args, v)
@@ -51,7 +51,7 @@ func func_exec(arguments []interface{}, binding Binding) (yaml.Node, EvaluationI
 	}
 	result, err := cachedExecute(args)
 	if err != nil {
-		info.Issue = "execution '" + args[0] + "' failed"
+		info.Issue = yaml.NewIssue("execution '%s' failed", args[0])
 		// expression set to undefined
 		return nil, info, false
 	}

--- a/dynaml/exec.go
+++ b/dynaml/exec.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
-func func_exec(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func func_exec(arguments []interface{}, binding Binding) (interface{}, EvaluationInfo, bool) {
 	info := DefaultInfo()
 
 	if len(arguments) < 1 {
@@ -60,7 +60,7 @@ func func_exec(arguments []interface{}, binding Binding) (yaml.Node, EvaluationI
 	execYML, err := yaml.Parse("exec", result)
 	if strings.HasPrefix(str, "---\n") && err == nil {
 		debug.Debug("exec: found yaml result %+v\n", execYML)
-		return execYML, info, true
+		return execYML.Value(), info, true
 	} else {
 		if strings.HasSuffix(str, "\n") {
 			str = str[:len(str)-1]
@@ -68,10 +68,10 @@ func func_exec(arguments []interface{}, binding Binding) (yaml.Node, EvaluationI
 		int64YML, err := strconv.ParseInt(str, 10, 64)
 		if err == nil {
 			debug.Debug("exec: found integer result: %s\n", int64YML)
-			return node(int64YML), info, true
+			return int64YML, info, true
 		}
 		debug.Debug("exec: found string result: %s\n", string(result))
-		return node(str), info, true
+		return str, info, true
 	}
 }
 
@@ -86,7 +86,7 @@ func getArg(i int, value interface{}) (string, bool) {
 		if i == 0 || value == nil {
 			return "", false
 		}
-		yaml, err := candiedyaml.Marshal(node(value))
+		yaml, err := candiedyaml.Marshal(node(value, nil))
 		if err != nil {
 			log.Fatalln("error marshalling manifest:", err)
 		}

--- a/dynaml/expression.go
+++ b/dynaml/expression.go
@@ -5,6 +5,7 @@ import (
 )
 
 type Binding interface {
+	GetLocalBinding() map[string]yaml.Node
 	FindFromRoot([]string) (yaml.Node, bool)
 	FindReference([]string) (yaml.Node, bool)
 	FindInStubs([]string) (yaml.Node, bool)

--- a/dynaml/expression.go
+++ b/dynaml/expression.go
@@ -9,6 +9,15 @@ type Binding interface {
 	FindFromRoot([]string) (yaml.Node, bool)
 	FindReference([]string) (yaml.Node, bool)
 	FindInStubs([]string) (yaml.Node, bool)
+
+	WithScope(step map[string]yaml.Node) Binding
+	WithPath(step string) Binding
+	RedirectOverwrite(path []string) Binding
+
+	Path() []string
+	StubPath() []string
+
+	Flow(source yaml.Node, shouldOverride bool) (yaml.Node, error)
 }
 
 type EvaluationInfo struct {

--- a/dynaml/expression.go
+++ b/dynaml/expression.go
@@ -26,11 +26,11 @@ type EvaluationInfo struct {
 	Merged       bool
 	Preferred    bool
 	KeyName      string
-	Issue        string
+	Issue        yaml.Issue
 }
 
 func DefaultInfo() EvaluationInfo {
-	return EvaluationInfo{nil, false, false, false, "", ""}
+	return EvaluationInfo{nil, false, false, false, "", yaml.Issue{}}
 }
 
 type Expression interface {
@@ -47,7 +47,7 @@ func (i EvaluationInfo) Join(o EvaluationInfo) EvaluationInfo {
 	if o.KeyName != "" {
 		i.KeyName = o.KeyName
 	}
-	if o.Issue != "" {
+	if o.Issue.Issue != "" {
 		i.Issue = o.Issue
 	}
 	return i
@@ -83,7 +83,7 @@ func ResolveIntegerExpressionOrPushEvaluation(e *Expression, resolved *bool, inf
 	if ok {
 		return i, infoe, true
 	} else {
-		infoe.Issue = "integer operand required"
+		infoe.Issue = yaml.NewIssue("integer operand required")
 		return 0, infoe, false
 	}
 }

--- a/dynaml/expression.go
+++ b/dynaml/expression.go
@@ -4,6 +4,11 @@ import (
 	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
+type Status interface {
+	error
+	Issue(string) yaml.Issue
+}
+
 type Binding interface {
 	GetLocalBinding() map[string]yaml.Node
 	FindFromRoot([]string) (yaml.Node, bool)
@@ -17,7 +22,7 @@ type Binding interface {
 	Path() []string
 	StubPath() []string
 
-	Flow(source yaml.Node, shouldOverride bool) (yaml.Node, error)
+	Flow(source yaml.Node, shouldOverride bool) (yaml.Node, Status)
 }
 
 type EvaluationInfo struct {

--- a/dynaml/failing_expr_helper_test.go
+++ b/dynaml/failing_expr_helper_test.go
@@ -1,11 +1,7 @@
 package dynaml
 
-import (
-	"github.com/cloudfoundry-incubator/spiff/yaml"
-)
-
 type FailingExpr struct{}
 
-func (FailingExpr) Evaluate(Binding) (yaml.Node, EvaluationInfo, bool) {
+func (FailingExpr) Evaluate(Binding) (interface{}, EvaluationInfo, bool) {
 	return nil, DefaultInfo(), false
 }

--- a/dynaml/fake_binding_helper_test.go
+++ b/dynaml/fake_binding_helper_test.go
@@ -23,11 +23,19 @@ func (c FakeBinding) StubPath() []string {
 	return c.stubPath
 }
 
+func (c FakeBinding) SourceName() string {
+	return "test"
+}
+
 func (c FakeBinding) RedirectOverwrite([]string) Binding {
 	return c
 }
 
 func (c FakeBinding) WithScope(map[string]yaml.Node) Binding {
+	return c
+}
+
+func (c FakeBinding) WithLocalScope(map[string]yaml.Node) Binding {
 	return c
 }
 
@@ -39,6 +47,10 @@ func (c FakeBinding) WithPath(step string) Binding {
 	newPath = make([]string, len(c.stubPath))
 	copy(newPath, c.stubPath)
 	c.stubPath = append(newPath, step)
+	return c
+}
+
+func (c FakeBinding) WithSource(source string) Binding {
 	return c
 }
 

--- a/dynaml/fake_binding_helper_test.go
+++ b/dynaml/fake_binding_helper_test.go
@@ -12,6 +12,10 @@ type FakeBinding struct {
 	FoundInStubs    map[string]yaml.Node
 }
 
+func (c FakeBinding) GetLocalBinding() map[string]yaml.Node {
+	return map[string]yaml.Node{}
+}
+
 func (c FakeBinding) FindFromRoot(path []string) (yaml.Node, bool) {
 	p := strings.Join(path, ".")
 	if len(path) == 0 {

--- a/dynaml/fake_binding_helper_test.go
+++ b/dynaml/fake_binding_helper_test.go
@@ -1,6 +1,7 @@
 package dynaml
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/cloudfoundry-incubator/spiff/yaml"
@@ -10,6 +11,36 @@ type FakeBinding struct {
 	FoundFromRoot   map[string]yaml.Node
 	FoundReferences map[string]yaml.Node
 	FoundInStubs    map[string]yaml.Node
+
+	path     []string
+	stubPath []string
+}
+
+func (c FakeBinding) Path() []string {
+	return c.path
+}
+
+func (c FakeBinding) StubPath() []string {
+	return c.stubPath
+}
+
+func (c FakeBinding) RedirectOverwrite([]string) Binding {
+	return c
+}
+
+func (c FakeBinding) WithScope(map[string]yaml.Node) Binding {
+	return c
+}
+
+func (c FakeBinding) WithPath(step string) Binding {
+	newPath := make([]string, len(c.path))
+	copy(newPath, c.path)
+	c.path = append(newPath, step)
+
+	newPath = make([]string, len(c.stubPath))
+	copy(newPath, c.stubPath)
+	c.stubPath = append(newPath, step)
+	return c
 }
 
 func (c FakeBinding) GetLocalBinding() map[string]yaml.Node {
@@ -33,4 +64,8 @@ func (c FakeBinding) FindReference(path []string) (yaml.Node, bool) {
 func (c FakeBinding) FindInStubs(path []string) (yaml.Node, bool) {
 	val, found := c.FoundInStubs[strings.Join(path, ".")]
 	return val, found
+}
+
+func (c FakeBinding) Flow(source yaml.Node, shouldOverride bool) (yaml.Node, error) {
+	return nil, fmt.Errorf("not implemented")
 }

--- a/dynaml/fake_binding_helper_test.go
+++ b/dynaml/fake_binding_helper_test.go
@@ -1,7 +1,6 @@
 package dynaml
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/cloudfoundry-incubator/spiff/yaml"
@@ -66,6 +65,6 @@ func (c FakeBinding) FindInStubs(path []string) (yaml.Node, bool) {
 	return val, found
 }
 
-func (c FakeBinding) Flow(source yaml.Node, shouldOverride bool) (yaml.Node, error) {
-	return nil, fmt.Errorf("not implemented")
+func (c FakeBinding) Flow(source yaml.Node, shouldOverride bool) (yaml.Node, Status) {
+	return nil, nil
 }

--- a/dynaml/format.go
+++ b/dynaml/format.go
@@ -1,0 +1,58 @@
+package dynaml
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+
+	"github.com/cloudfoundry-incubator/candiedyaml"
+)
+
+func func_format(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	return format("format", arguments, binding)
+}
+
+func format(name string, arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	info := DefaultInfo()
+
+	if len(arguments) < 1 {
+		info.Issue = yaml.NewIssue("alt least one argument required for '%s'", name)
+		return nil, info, false
+	}
+
+	args := make([]interface{}, len(arguments))
+	for i, arg := range arguments {
+		switch v := arg.(type) {
+		case []yaml.Node:
+			yaml, err := candiedyaml.Marshal(node(v))
+			if err != nil {
+				log.Fatalln("error marshalling yaml fragment:", err)
+			}
+			args[i] = string(yaml)
+		case map[string]yaml.Node:
+			yaml, err := candiedyaml.Marshal(node(v))
+			if err != nil {
+				log.Fatalln("error marshalling yaml fragment:", err)
+			}
+			args[i] = string(yaml)
+		case TemplateValue:
+			yaml, err := candiedyaml.Marshal(v.Orig)
+			if err != nil {
+				log.Fatalln("error marshalling template:", err)
+			}
+			args[i] = string(yaml)
+		case LambdaValue:
+			args[i] = v.String()
+		default:
+			args[i] = arg
+		}
+	}
+
+	f, ok := args[0].(string)
+	if !ok {
+		info.Issue = yaml.NewIssue("%s: format must be string", format)
+		return nil, info, false
+	}
+	return node(fmt.Sprintf(f, args[1:]...)), info, true
+}

--- a/dynaml/format.go
+++ b/dynaml/format.go
@@ -9,11 +9,11 @@ import (
 	"github.com/cloudfoundry-incubator/candiedyaml"
 )
 
-func func_format(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func func_format(arguments []interface{}, binding Binding) (interface{}, EvaluationInfo, bool) {
 	return format("format", arguments, binding)
 }
 
-func format(name string, arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func format(name string, arguments []interface{}, binding Binding) (interface{}, EvaluationInfo, bool) {
 	info := DefaultInfo()
 
 	if len(arguments) < 1 {
@@ -25,13 +25,13 @@ func format(name string, arguments []interface{}, binding Binding) (yaml.Node, E
 	for i, arg := range arguments {
 		switch v := arg.(type) {
 		case []yaml.Node:
-			yaml, err := candiedyaml.Marshal(node(v))
+			yaml, err := candiedyaml.Marshal(node(v, nil))
 			if err != nil {
 				log.Fatalln("error marshalling yaml fragment:", err)
 			}
 			args[i] = string(yaml)
 		case map[string]yaml.Node:
-			yaml, err := candiedyaml.Marshal(node(v))
+			yaml, err := candiedyaml.Marshal(node(v, nil))
 			if err != nil {
 				log.Fatalln("error marshalling yaml fragment:", err)
 			}
@@ -54,5 +54,5 @@ func format(name string, arguments []interface{}, binding Binding) (yaml.Node, E
 		info.Issue = yaml.NewIssue("%s: format must be string", format)
 		return nil, info, false
 	}
-	return node(fmt.Sprintf(f, args[1:]...)), info, true
+	return fmt.Sprintf(f, args[1:]...), info, true
 }

--- a/dynaml/integer.go
+++ b/dynaml/integer.go
@@ -2,16 +2,14 @@ package dynaml
 
 import (
 	"strconv"
-
-	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
 type IntegerExpr struct {
 	Value int64
 }
 
-func (e IntegerExpr) Evaluate(Binding) (yaml.Node, EvaluationInfo, bool) {
-	return node(e.Value), DefaultInfo(), true
+func (e IntegerExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
+	return e.Value, DefaultInfo(), true
 }
 
 func (e IntegerExpr) String() string {

--- a/dynaml/ip.go
+++ b/dynaml/ip.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
-func func_ip(op func(ip net.IP, cidr *net.IPNet) interface{}, arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func func_ip(op func(ip net.IP, cidr *net.IPNet) interface{}, arguments []interface{}, binding Binding) (interface{}, EvaluationInfo, bool) {
 	info := DefaultInfo()
 
 	if len(arguments) != 1 {
@@ -28,22 +28,22 @@ func func_ip(op func(ip net.IP, cidr *net.IPNet) interface{}, arguments []interf
 		return nil, info, false
 	}
 
-	return node(op(ip, cidr)), info, true
+	return op(ip, cidr), info, true
 }
 
-func func_minIP(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func func_minIP(arguments []interface{}, binding Binding) (interface{}, EvaluationInfo, bool) {
 	return func_ip(func(ip net.IP, cidr *net.IPNet) interface{} {
 		return ip.Mask(cidr.Mask).String()
 	}, arguments, binding)
 }
 
-func func_maxIP(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func func_maxIP(arguments []interface{}, binding Binding) (interface{}, EvaluationInfo, bool) {
 	return func_ip(func(ip net.IP, cidr *net.IPNet) interface{} {
 		return MaxIP(cidr).String()
 	}, arguments, binding)
 }
 
-func func_numIP(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func func_numIP(arguments []interface{}, binding Binding) (interface{}, EvaluationInfo, bool) {
 	return func_ip(func(ip net.IP, cidr *net.IPNet) interface{} {
 		ones, _ := cidr.Mask.Size()
 		return int64(1 << (32 - uint32(ones)))

--- a/dynaml/ip.go
+++ b/dynaml/ip.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
-func func_ip(op func(ip net.IP, cidr *net.IPNet) net.IP, arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func func_ip(op func(ip net.IP, cidr *net.IPNet) interface{}, arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
 	info := DefaultInfo()
 
 	if len(arguments) != 1 {
@@ -28,18 +28,25 @@ func func_ip(op func(ip net.IP, cidr *net.IPNet) net.IP, arguments []interface{}
 		return nil, info, false
 	}
 
-	return node(op(ip, cidr).String()), info, true
+	return node(op(ip, cidr)), info, true
 }
 
 func func_minIP(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
-	return func_ip(func(ip net.IP, cidr *net.IPNet) net.IP {
-		return ip.Mask(cidr.Mask)
+	return func_ip(func(ip net.IP, cidr *net.IPNet) interface{} {
+		return ip.Mask(cidr.Mask).String()
 	}, arguments, binding)
 }
 
 func func_maxIP(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
-	return func_ip(func(ip net.IP, cidr *net.IPNet) net.IP {
-		return MaxIP(cidr)
+	return func_ip(func(ip net.IP, cidr *net.IPNet) interface{} {
+		return MaxIP(cidr).String()
+	}, arguments, binding)
+}
+
+func func_numIP(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	return func_ip(func(ip net.IP, cidr *net.IPNet) interface{} {
+		ones, _ := cidr.Mask.Size()
+		return int64(1 << (32 - uint32(ones)))
 	}, arguments, binding)
 }
 

--- a/dynaml/ip.go
+++ b/dynaml/ip.go
@@ -11,20 +11,20 @@ func func_ip(op func(ip net.IP, cidr *net.IPNet) interface{}, arguments []interf
 	info := DefaultInfo()
 
 	if len(arguments) != 1 {
-		info.Issue = "only one argument expected for CIDR function"
+		info.Issue = yaml.NewIssue("only one argument expected for CIDR function")
 		return nil, info, false
 	}
 
 	str, ok := arguments[0].(string)
 	if !ok {
-		info.Issue = "CIDR argument required"
+		info.Issue = yaml.NewIssue("CIDR argument required")
 		return nil, info, false
 	}
 
 	ip, cidr, err := net.ParseCIDR(str)
 
 	if err != nil {
-		info.Issue = "CIDR argument required"
+		info.Issue = yaml.NewIssue("CIDR argument required")
 		return nil, info, false
 	}
 

--- a/dynaml/join.go
+++ b/dynaml/join.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
-func func_join(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func func_join(arguments []interface{}, binding Binding) (interface{}, EvaluationInfo, bool) {
 	info := DefaultInfo()
 
 	if len(arguments) < 1 {
@@ -48,5 +48,5 @@ func func_join(arguments []interface{}, binding Binding) (yaml.Node, EvaluationI
 		}
 	}
 
-	return node(strings.Join(args[1:], args[0])), info, true
+	return strings.Join(args[1:], args[0]), info, true
 }

--- a/dynaml/join.go
+++ b/dynaml/join.go
@@ -1,7 +1,6 @@
 package dynaml
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -26,7 +25,7 @@ func func_join(arguments []interface{}, binding Binding) (yaml.Node, EvaluationI
 			args = append(args, strconv.FormatBool(v))
 		case []yaml.Node:
 			if i == 0 {
-				info.Issue = "first argument for join must be a string"
+				info.Issue = yaml.NewIssue("first argument for join must be a string")
 				return nil, info, false
 			}
 			for _, elem := range v {
@@ -38,13 +37,13 @@ func func_join(arguments []interface{}, binding Binding) (yaml.Node, EvaluationI
 				case bool:
 					args = append(args, strconv.FormatBool(e))
 				default:
-					info.Issue = fmt.Sprintf("elements of list(arg %d) to join must be simple values", i)
+					info.Issue = yaml.NewIssue("elements of list(arg %d) to join must be simple values", i)
 					return nil, info, false
 				}
 			}
 		case nil:
 		default:
-			info.Issue = fmt.Sprintf("argument %d to join must be simple value or list", i)
+			info.Issue = yaml.NewIssue("argument %d to join must be simple value or list", i)
 			return nil, info, false
 		}
 	}

--- a/dynaml/lambda.go
+++ b/dynaml/lambda.go
@@ -119,19 +119,23 @@ func (e LambdaValue) Evaluate(args []interface{}, binding Binding) (yaml.Node, E
 		return node(LambdaValue{LambdaExpr{rest, e.lambda.E}, inp}), DefaultInfo(), true
 	}
 
-	ctx := MapContext{binding, inp}
-	return e.lambda.E.Evaluate(ctx)
+	return e.lambda.E.Evaluate(newCallBinding(inp, binding))
 }
 
-type MapContext struct {
+type CallBinding struct {
 	Binding
 	names map[string]yaml.Node
 }
 
-func (c MapContext) GetLocalBinding() map[string]yaml.Node {
+func (c CallBinding) GetLocalBinding() map[string]yaml.Node {
 	return c.names
 }
 
+func newCallBinding(names map[string]yaml.Node, binding Binding) Binding {
+	return CallBinding{binding.WithScope(names), names}
+}
+
+/*
 func (c MapContext) FindReference(path []string) (yaml.Node, bool) {
 	for name, node := range c.names {
 		if len(path) >= 1 && path[0] == name {
@@ -145,3 +149,4 @@ func (c MapContext) FindReference(path []string) (yaml.Node, bool) {
 	debug.Debug("lambda: forward find ref: %v\n", path)
 	return c.Binding.FindReference(path)
 }
+*/

--- a/dynaml/lambda.go
+++ b/dynaml/lambda.go
@@ -47,9 +47,6 @@ func (e LambdaRefExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, boo
 		lambda = v
 
 	case string:
-		if len(v) > 0 && v[0] == '|' {
-			v = "lambda " + v
-		}
 		debug.Debug("LRef: parsing '%s'\n", v)
 		expr, err := Parse(v, e.Path, e.StubPath)
 		if err != nil {

--- a/dynaml/lambda.go
+++ b/dynaml/lambda.go
@@ -1,0 +1,122 @@
+package dynaml
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry-incubator/spiff/debug"
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+type LambdaExpr struct {
+	Names []string
+	E     Expression
+}
+
+func (e LambdaExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	info := DefaultInfo()
+	return node(LambdaValue{e}), info, true
+}
+
+func (e LambdaExpr) String() string {
+	str := ""
+	for _, n := range e.Names {
+		str += "," + n
+	}
+	return fmt.Sprintf("lambda|%s|->%s", str[1:], e.E)
+}
+
+type LambdaRefExpr struct {
+	Source   Expression
+	Path     []string
+	StubPath []string
+}
+
+func (e LambdaRefExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	var lambda LambdaValue
+	resolved := true
+	value, info, ok := ResolveExpressionOrPushEvaluation(&e.Source, &resolved, nil, binding)
+	if !ok {
+		return nil, info, false
+	}
+	if !resolved {
+		return node(e), info, false
+	}
+
+	switch v := value.(type) {
+	case LambdaValue:
+		lambda = v
+
+	case string:
+		if len(v) > 0 && v[0] == '|' {
+			v = "lambda " + v
+		}
+		debug.Debug("LRef: parsing '%s'\n", v)
+		expr, err := Parse(v, e.Path, e.StubPath)
+		if err != nil {
+			debug.Debug("cannot parse: %s\n", err.Error())
+			info.Issue = fmt.Sprintf("cannot parse lamba expression '%s'", v)
+			return nil, info, false
+		}
+		lexpr, ok := expr.(LambdaExpr)
+		if !ok {
+			debug.Debug("no lambda expression: %T\n", expr)
+			info.Issue = fmt.Sprintf("'%s' is no lambda expression", v)
+			return nil, info, false
+		}
+		lambda = LambdaValue{lexpr}
+
+	default:
+		info.Issue = "lambda reference must resolve to lambda value or string"
+	}
+	debug.Debug("found lambda: %s\n", lambda)
+	return node(lambda), info, true
+}
+
+func (e LambdaRefExpr) String() string {
+	return fmt.Sprintf("lambda %s", e.Source)
+}
+
+type LambdaValue struct {
+	lambda LambdaExpr
+}
+
+func (e LambdaValue) String() string {
+	return fmt.Sprintf("%s", e.lambda)
+}
+
+func (e LambdaValue) MarshalYAML() (tag string, value interface{}) {
+	return "", e.String()
+}
+
+func (e LambdaValue) Evaluate(args []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	info := DefaultInfo()
+	if len(args) != len(e.lambda.Names) {
+		info.Issue = fmt.Sprintf("found %d argument(s), but expects %d", len(args), len(e.lambda.Names))
+		return nil, info, false
+	}
+	inp := map[string]yaml.Node{}
+	for i, name := range e.lambda.Names {
+		inp[name] = node(args[i])
+	}
+	ctx := MapContext{binding, inp}
+	return e.lambda.E.Evaluate(ctx)
+}
+
+type MapContext struct {
+	Binding
+	names map[string]yaml.Node
+}
+
+func (c MapContext) FindReference(path []string) (yaml.Node, bool) {
+	for name, node := range c.names {
+		if len(path) >= 1 && path[0] == name {
+			debug.Debug("lambda: catch find ref: %v\n", path)
+			if len(path) == 1 {
+				return node, true
+			}
+			return yaml.Find(node, path[1:]...)
+		}
+	}
+	debug.Debug("lambda: forward find ref: %v\n", path)
+	return c.Binding.FindReference(path)
+}

--- a/dynaml/lambda.go
+++ b/dynaml/lambda.go
@@ -51,7 +51,7 @@ func (e LambdaRefExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, boo
 		expr, err := Parse(v, e.Path, e.StubPath)
 		if err != nil {
 			debug.Debug("cannot parse: %s\n", err.Error())
-			info.Issue = yaml.NewIssue("cannot parse lamba expression '%s'", v)
+			info.Issue = yaml.NewIssue("cannot parse lamba expression '%s'")
 			return nil, info, false
 		}
 		lexpr, ok := expr.(LambdaExpr)

--- a/dynaml/lambda.go
+++ b/dynaml/lambda.go
@@ -51,19 +51,19 @@ func (e LambdaRefExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, boo
 		expr, err := Parse(v, e.Path, e.StubPath)
 		if err != nil {
 			debug.Debug("cannot parse: %s\n", err.Error())
-			info.Issue = fmt.Sprintf("cannot parse lamba expression '%s'", v)
+			info.Issue = yaml.NewIssue("cannot parse lamba expression '%s'", v)
 			return nil, info, false
 		}
 		lexpr, ok := expr.(LambdaExpr)
 		if !ok {
 			debug.Debug("no lambda expression: %T\n", expr)
-			info.Issue = fmt.Sprintf("'%s' is no lambda expression", v)
+			info.Issue = yaml.NewIssue("'%s' is no lambda expression", v)
 			return nil, info, false
 		}
 		lambda = LambdaValue{lexpr, binding.GetLocalBinding()}
 
 	default:
-		info.Issue = "lambda reference must resolve to lambda value or string"
+		info.Issue = yaml.NewIssue("lambda reference must resolve to lambda value or string")
 	}
 	debug.Debug("found lambda: %s\n", lambda)
 	return node(lambda), info, true
@@ -100,7 +100,7 @@ func (e LambdaValue) Evaluate(args []interface{}, binding Binding) (yaml.Node, E
 	info := DefaultInfo()
 
 	if len(args) > len(e.lambda.Names) {
-		info.Issue = fmt.Sprintf("found %d argument(s), but expects %d", len(args), len(e.lambda.Names))
+		info.Issue = yaml.NewIssue("found %d argument(s), but expects %d", len(args), len(e.lambda.Names))
 		return nil, info, false
 	}
 	inp := map[string]yaml.Node{}

--- a/dynaml/length.go
+++ b/dynaml/length.go
@@ -4,7 +4,7 @@ import (
 	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
-func func_length(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func func_length(arguments []interface{}, binding Binding) (interface{}, EvaluationInfo, bool) {
 	var result interface{}
 	info := DefaultInfo()
 
@@ -25,5 +25,5 @@ func func_length(arguments []interface{}, binding Binding) (yaml.Node, Evaluatio
 		return nil, info, false
 
 	}
-	return node(result), info, true
+	return result, info, true
 }

--- a/dynaml/length.go
+++ b/dynaml/length.go
@@ -1,0 +1,29 @@
+package dynaml
+
+import (
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+func func_length(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	var result interface{}
+	info := DefaultInfo()
+
+	if len(arguments) != 1 {
+		info.Issue = "lebgth takes exactly 1 arguments"
+		return nil, info, false
+	}
+
+	switch v := arguments[0].(type) {
+	case []yaml.Node:
+		result = len(v)
+	case map[string]yaml.Node:
+		result = len(v)
+	case string:
+		result = len(v)
+	default:
+		info.Issue = "invalid type for function length"
+		return nil, info, false
+
+	}
+	return node(result), info, true
+}

--- a/dynaml/length.go
+++ b/dynaml/length.go
@@ -9,7 +9,7 @@ func func_length(arguments []interface{}, binding Binding) (yaml.Node, Evaluatio
 	info := DefaultInfo()
 
 	if len(arguments) != 1 {
-		info.Issue = "lebgth takes exactly 1 arguments"
+		info.Issue = yaml.NewIssue("length takes exactly 1 arguments")
 		return nil, info, false
 	}
 
@@ -21,7 +21,7 @@ func func_length(arguments []interface{}, binding Binding) (yaml.Node, Evaluatio
 	case string:
 		result = len(v)
 	default:
-		info.Issue = "invalid type for function length"
+		info.Issue = yaml.NewIssue("invalid type for function length")
 		return nil, info, false
 
 	}

--- a/dynaml/list.go
+++ b/dynaml/list.go
@@ -11,7 +11,7 @@ type ListExpr struct {
 	Contents []Expression
 }
 
-func (e ListExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e ListExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 	resolved := true
 
 	values, info, ok := ResolveExpressionListOrPushEvaluation(&e.Contents, &resolved, nil, binding)
@@ -20,14 +20,14 @@ func (e ListExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 		return nil, info, false
 	}
 	if !resolved {
-		return node(e), info, true
+		return e, info, true
 	}
 
 	nodes := []yaml.Node{}
 	for i, _ := range values {
-		nodes = append(nodes, node(values[i]))
+		nodes = append(nodes, node(values[i], binding))
 	}
-	return node(nodes), info, true
+	return nodes, info, true
 }
 
 func (e ListExpr) String() string {

--- a/dynaml/list_test.go
+++ b/dynaml/list_test.go
@@ -16,7 +16,7 @@ var _ = Describe("lists", func() {
 			},
 		}
 
-		Expect(expr).To(EvaluateAs([]yaml.Node{node(1), node("two")}, FakeBinding{}))
+		Expect(expr).To(EvaluateAs([]yaml.Node{node(1, nil), node("two", nil)}, FakeBinding{}))
 	})
 
 	Context("when empty", func() {

--- a/dynaml/log_and.go
+++ b/dynaml/log_and.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/cloudfoundry-incubator/spiff/debug"
-	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
 const (
@@ -16,20 +15,20 @@ type LogAndExpr struct {
 	B Expression
 }
 
-func (e LogAndExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e LogAndExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 	a, b, info, resolved, ok := resolveLOperands(e.A, e.B, binding)
 	if !ok {
 		return nil, info, false
 	}
 	if !resolved {
-		return node(e), info, true
+		return e, info, true
 	}
 	debug.Debug("AND: %#v, %#v\n", a, b)
 	inta, ok := a.(int64)
 	if ok {
-		return node(inta & b.(int64)), info, true
+		return inta & b.(int64), info, true
 	}
-	return node(toBool(a) && toBool(b)), info, true
+	return toBool(a) && toBool(b), info, true
 }
 
 func (e LogAndExpr) String() string {

--- a/dynaml/log_and.go
+++ b/dynaml/log_and.go
@@ -1,0 +1,37 @@
+package dynaml
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry-incubator/spiff/debug"
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+const (
+	OpAnd = "-and"
+)
+
+type LogAndExpr struct {
+	A Expression
+	B Expression
+}
+
+func (e LogAndExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	a, b, info, resolved, ok := resolveLOperands(e.A, e.B, binding)
+	if !ok {
+		return nil, info, false
+	}
+	if !resolved {
+		return node(e), info, true
+	}
+	debug.Debug("AND: %#v, %#v\n", a, b)
+	inta, ok := a.(int64)
+	if ok {
+		return node(inta & b.(int64)), info, true
+	}
+	return node(toBool(a) && toBool(b)), info, true
+}
+
+func (e LogAndExpr) String() string {
+	return fmt.Sprintf("%s %s %s", e.A, OpAnd, e.B)
+}

--- a/dynaml/log_and_test.go
+++ b/dynaml/log_and_test.go
@@ -1,0 +1,112 @@
+package dynaml
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("logical and", func() {
+	Context("on boolean", func() {
+		It("true and true", func() {
+			expr := LogAndExpr{
+				BooleanExpr{true},
+				BooleanExpr{true},
+			}
+
+			Expect(expr).To(EvaluateAs(true, FakeBinding{}))
+		})
+
+		It("true and false", func() {
+			expr := LogAndExpr{
+				BooleanExpr{true},
+				BooleanExpr{false},
+			}
+
+			Expect(expr).To(EvaluateAs(false, FakeBinding{}))
+		})
+
+		It("false name true", func() {
+			expr := LogAndExpr{
+				BooleanExpr{false},
+				BooleanExpr{true},
+			}
+
+			Expect(expr).To(EvaluateAs(false, FakeBinding{}))
+		})
+
+		It("false and false", func() {
+			expr := LogAndExpr{
+				BooleanExpr{false},
+				BooleanExpr{false},
+			}
+
+			Expect(expr).To(EvaluateAs(false, FakeBinding{}))
+		})
+	})
+
+	Context("when both sides fail", func() {
+		It("fails", func() {
+			expr := LogAndExpr{
+				FailingExpr{},
+				FailingExpr{},
+			}
+
+			Expect(expr).To(FailToEvaluate(FakeBinding{}))
+		})
+	})
+
+	Context("when the left-hand side fails", func() {
+		It("fails", func() {
+			expr := LogAndExpr{
+				FailingExpr{},
+				IntegerExpr{2},
+			}
+
+			Expect(expr).To(FailToEvaluate(FakeBinding{}))
+		})
+	})
+
+	Context("when the right-hand side fails", func() {
+		It("fails", func() {
+			expr := LogAndExpr{
+				IntegerExpr{1},
+				FailingExpr{},
+			}
+
+			Expect(expr).To(FailToEvaluate(FakeBinding{}))
+		})
+	})
+
+	Context("when the left-hand side is nil", func() {
+		It("returns false", func() {
+			expr := LogAndExpr{
+				NilExpr{},
+				BooleanExpr{true},
+			}
+
+			Expect(expr).To(EvaluateAs(false, FakeBinding{}))
+		})
+	})
+
+	Context("when the right side is nil", func() {
+		It("returns false", func() {
+			expr := LogAndExpr{
+				BooleanExpr{true},
+				NilExpr{},
+			}
+
+			Expect(expr).To(EvaluateAs(false, FakeBinding{}))
+		})
+	})
+
+	Context("when both sides are integers", func() {
+		It("evaluates bit-wise and", func() {
+			expr := LogAndExpr{
+				IntegerExpr{5},
+				IntegerExpr{6},
+			}
+
+			Expect(expr).To(EvaluateAs(4, FakeBinding{}))
+		})
+	})
+})

--- a/dynaml/log_or.go
+++ b/dynaml/log_or.go
@@ -1,0 +1,71 @@
+package dynaml
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry-incubator/spiff/debug"
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+const (
+	OpOr = "-or"
+)
+
+type LogOrExpr struct {
+	A Expression
+	B Expression
+}
+
+func (e LogOrExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	a, b, info, resolved, ok := resolveLOperands(e.A, e.B, binding)
+	if !ok {
+		return nil, info, false
+	}
+	if !resolved {
+		return node(e), info, true
+	}
+	debug.Debug("OR: %#v, %#v\n", a, b)
+	inta, ok := a.(int64)
+	if ok {
+		return node(inta | b.(int64)), info, true
+	}
+	return node(toBool(a) || toBool(b)), info, true
+}
+
+func (e LogOrExpr) String() string {
+	return fmt.Sprintf("%s %s %s", e.A, OpOr, e.B)
+}
+
+func resolveLOperands(a, b Expression, binding Binding) (eff_a, eff_b interface{}, info EvaluationInfo, resolved bool, ok bool) {
+	var va, vb yaml.Node
+	var infoa, infob EvaluationInfo
+
+	va, infoa, ok = a.Evaluate(binding)
+	if ok {
+		if isExpression(va) {
+			return nil, nil, infoa, false, true
+		}
+
+		vb, infob, ok = b.Evaluate(binding)
+		info = infoa.Join(infob)
+		if !ok {
+			return nil, nil, info, false, false
+		}
+
+		if isExpression(vb) {
+			return nil, nil, info, false, true
+		}
+
+		resolved = true
+		eff_a, ok = va.Value().(int64)
+		if ok {
+			eff_b, ok = vb.Value().(int64)
+			if ok {
+				return
+			}
+		}
+		return toBool(va.Value()), toBool(vb.Value()), info, true, true
+	}
+
+	return nil, nil, info, false, false
+}

--- a/dynaml/log_or_test.go
+++ b/dynaml/log_or_test.go
@@ -1,0 +1,112 @@
+package dynaml
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("logical or", func() {
+	Context("on boolean", func() {
+		It("true or true", func() {
+			expr := LogOrExpr{
+				BooleanExpr{true},
+				BooleanExpr{true},
+			}
+
+			Expect(expr).To(EvaluateAs(true, FakeBinding{}))
+		})
+
+		It("true or false", func() {
+			expr := LogOrExpr{
+				BooleanExpr{true},
+				BooleanExpr{false},
+			}
+
+			Expect(expr).To(EvaluateAs(true, FakeBinding{}))
+		})
+
+		It("false or true", func() {
+			expr := LogOrExpr{
+				BooleanExpr{false},
+				BooleanExpr{true},
+			}
+
+			Expect(expr).To(EvaluateAs(true, FakeBinding{}))
+		})
+
+		It("false or false", func() {
+			expr := LogOrExpr{
+				BooleanExpr{false},
+				BooleanExpr{false},
+			}
+
+			Expect(expr).To(EvaluateAs(false, FakeBinding{}))
+		})
+	})
+
+	Context("when both sides fail", func() {
+		It("fails", func() {
+			expr := LogOrExpr{
+				FailingExpr{},
+				FailingExpr{},
+			}
+
+			Expect(expr).To(FailToEvaluate(FakeBinding{}))
+		})
+	})
+
+	Context("when the left-hand side fails", func() {
+		It("fails", func() {
+			expr := LogOrExpr{
+				FailingExpr{},
+				IntegerExpr{2},
+			}
+
+			Expect(expr).To(FailToEvaluate(FakeBinding{}))
+		})
+	})
+
+	Context("when the right-hand side fails", func() {
+		It("fails", func() {
+			expr := LogOrExpr{
+				IntegerExpr{1},
+				FailingExpr{},
+			}
+
+			Expect(expr).To(FailToEvaluate(FakeBinding{}))
+		})
+	})
+
+	Context("when the left-hand side is nil", func() {
+		It("returns the right-hand side", func() {
+			expr := LogOrExpr{
+				NilExpr{},
+				BooleanExpr{true},
+			}
+
+			Expect(expr).To(EvaluateAs(true, FakeBinding{}))
+		})
+	})
+
+	Context("when the right side is nil", func() {
+		It("returns the left-hand side", func() {
+			expr := LogOrExpr{
+				BooleanExpr{true},
+				NilExpr{},
+			}
+
+			Expect(expr).To(EvaluateAs(true, FakeBinding{}))
+		})
+	})
+
+	Context("when both sides are integers", func() {
+		It("evaluates bit-wise or", func() {
+			expr := LogOrExpr{
+				IntegerExpr{5},
+				IntegerExpr{6},
+			}
+
+			Expect(expr).To(EvaluateAs(7, FakeBinding{}))
+		})
+	})
+})

--- a/dynaml/mapping.go
+++ b/dynaml/mapping.go
@@ -9,9 +9,8 @@ import (
 )
 
 type MapExpr struct {
-	A     Expression
-	Names []string
-	B     Expression
+	A      Expression
+	Lambda Expression
 }
 
 func (e MapExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
@@ -22,18 +21,29 @@ func (e MapExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 	if !ok {
 		return nil, info, false
 	}
-	if !resolved {
-		return node(e), info, ok
+	lvalue, infoe, ok := ResolveExpressionOrPushEvaluation(&e.Lambda, &resolved, nil, binding)
+	if !ok {
+		return nil, info, false
 	}
 
-	debug.Debug("map: using expression %+v\n", e.B)
+	if !resolved {
+		return node(e), info.Join(infoe), ok
+	}
+
+	lambda, ok := lvalue.(LambdaValue)
+	if !ok {
+		infoe.Issue = "mapping requires a lambda value"
+		return nil, infoe, false
+	}
+
+	debug.Debug("map: using lambda %+v\n", lambda)
 	var result []yaml.Node
 	switch value.(type) {
 	case []yaml.Node:
-		result, info, ok = mapList(value.([]yaml.Node), e.Names, e.B, binding)
+		result, info, ok = mapList(value.([]yaml.Node), lambda, binding)
 
 	case map[string]yaml.Node:
-		result, info, ok = mapMap(value.(map[string]yaml.Node), e.Names, e.B, binding)
+		result, info, ok = mapMap(value.(map[string]yaml.Node), lambda, binding)
 
 	default:
 		info.Issue = "map or list required for mapping"
@@ -50,26 +60,28 @@ func (e MapExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 }
 
 func (e MapExpr) String() string {
-	str := ""
-	for _, n := range e.Names {
-		str = "," + n + str
+	lambda, ok := e.Lambda.(LambdaExpr)
+	if ok {
+		return fmt.Sprintf("map[%s%s]", e.A, fmt.Sprintf("%s", lambda)[len("lambda"):])
+	} else {
+		return fmt.Sprintf("map[%s|%s]", e.A, e.Lambda)
 	}
-	return fmt.Sprintf("map[%s|%s|->%s]", e.A, str[1:], e.B)
 }
 
-func mapList(source []yaml.Node, names []string, e Expression, binding Binding) ([]yaml.Node, EvaluationInfo, bool) {
-	inp := map[string]yaml.Node{}
+func mapList(source []yaml.Node, e LambdaValue, binding Binding) ([]yaml.Node, EvaluationInfo, bool) {
+	inp := make([]interface{}, len(e.lambda.Names))
 	result := []yaml.Node{}
 	info := DefaultInfo()
 
+	if len(e.lambda.Names) > 2 {
+		info.Issue = "mapping expression take a maximum of 2 arguments"
+		return nil, info, false
+	}
 	for i, n := range source {
 		debug.Debug("map:  mapping for %d: %+v\n", i, n)
-		inp[names[0]] = n
-		if len(names) > 1 {
-			inp[names[1]] = node(i)
-		}
-		ctx := MapContext{binding, inp}
-		mapped, info, ok := e.Evaluate(ctx)
+		inp[0] = i
+		inp[len(inp)-1] = n.Value()
+		mapped, info, ok := e.Evaluate(inp, binding)
 		if !ok {
 			debug.Debug("map:  %d %+v: failed\n", i, n)
 			return nil, info, false
@@ -86,8 +98,8 @@ func mapList(source []yaml.Node, names []string, e Expression, binding Binding) 
 	return result, info, true
 }
 
-func mapMap(source map[string]yaml.Node, names []string, e Expression, binding Binding) ([]yaml.Node, EvaluationInfo, bool) {
-	inp := map[string]yaml.Node{}
+func mapMap(source map[string]yaml.Node, e LambdaValue, binding Binding) ([]yaml.Node, EvaluationInfo, bool) {
+	inp := make([]interface{}, len(e.lambda.Names))
 	result := []yaml.Node{}
 	info := DefaultInfo()
 
@@ -95,12 +107,9 @@ func mapMap(source map[string]yaml.Node, names []string, e Expression, binding B
 	for _, k := range keys {
 		n := source[k]
 		debug.Debug("map:  mapping for %s: %+v\n", k, n)
-		inp[names[0]] = n
-		if len(names) > 1 {
-			inp[names[1]] = node(k)
-		}
-		ctx := MapContext{binding, inp}
-		mapped, info, ok := e.Evaluate(ctx)
+		inp[0] = k
+		inp[len(inp)-1] = n.Value()
+		mapped, info, ok := e.Evaluate(inp, binding)
 		if !ok {
 			debug.Debug("map:  %s %+v: failed\n", k, n)
 			return nil, info, false

--- a/dynaml/mapping.go
+++ b/dynaml/mapping.go
@@ -8,25 +8,6 @@ import (
 	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
-type MapContext struct {
-	Binding
-	names map[string]yaml.Node
-}
-
-func (c MapContext) FindReference(path []string) (yaml.Node, bool) {
-	for name, node := range c.names {
-		if len(path) >= 1 && path[0] == name {
-			debug.Debug("map: catch find ref: %v\n", path)
-			if len(path) == 1 {
-				return node, true
-			}
-			return yaml.Find(node, path[1:]...)
-		}
-	}
-	debug.Debug("map: forward find ref: %v\n", path)
-	return c.Binding.FindReference(path)
-}
-
 type MapExpr struct {
 	A     Expression
 	Names []string

--- a/dynaml/mapping.go
+++ b/dynaml/mapping.go
@@ -13,7 +13,7 @@ type MapExpr struct {
 	Lambda Expression
 }
 
-func (e MapExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e MapExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 	resolved := true
 
 	debug.Debug("evaluate mapping\n")
@@ -27,7 +27,7 @@ func (e MapExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 	}
 
 	if !resolved {
-		return node(e), info.Join(infoe), ok
+		return e, info.Join(infoe), ok
 	}
 
 	lambda, ok := lvalue.(LambdaValue)
@@ -53,10 +53,10 @@ func (e MapExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 		return nil, info, false
 	}
 	if result == nil {
-		return node(e), info, true
+		return e, info, true
 	}
 	debug.Debug("map: --> %+v\n", result)
-	return node(result), info, true
+	return result, info, true
 }
 
 func (e MapExpr) String() string {
@@ -87,13 +87,13 @@ func mapList(source []yaml.Node, e LambdaValue, binding Binding) ([]yaml.Node, E
 			return nil, info, false
 		}
 
-		_, ok = mapped.Value().(Expression)
+		_, ok = mapped.(Expression)
 		if ok {
 			debug.Debug("map:  %d unresolved  -> KEEP\n")
 			return nil, info, true
 		}
 		debug.Debug("map:  %d --> %+v\n", i, mapped)
-		result = append(result, mapped)
+		result = append(result, node(mapped, info))
 	}
 	return result, info, true
 }
@@ -115,13 +115,13 @@ func mapMap(source map[string]yaml.Node, e LambdaValue, binding Binding) ([]yaml
 			return nil, info, false
 		}
 
-		_, ok = mapped.Value().(Expression)
+		_, ok = mapped.(Expression)
 		if ok {
 			debug.Debug("map:  %d unresolved  -> KEEP\n")
 			return nil, info, true
 		}
 		debug.Debug("map:  %s --> %+v\n", k, mapped)
-		result = append(result, mapped)
+		result = append(result, node(mapped, info))
 	}
 	return result, info, true
 }

--- a/dynaml/mapping.go
+++ b/dynaml/mapping.go
@@ -32,7 +32,7 @@ func (e MapExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 
 	lambda, ok := lvalue.(LambdaValue)
 	if !ok {
-		infoe.Issue = "mapping requires a lambda value"
+		infoe.Issue = yaml.NewIssue("mapping requires a lambda value")
 		return nil, infoe, false
 	}
 
@@ -46,7 +46,7 @@ func (e MapExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 		result, info, ok = mapMap(value.(map[string]yaml.Node), lambda, binding)
 
 	default:
-		info.Issue = "map or list required for mapping"
+		info.Issue = yaml.NewIssue("map or list required for mapping")
 		return nil, info, false
 	}
 	if !ok {
@@ -74,7 +74,7 @@ func mapList(source []yaml.Node, e LambdaValue, binding Binding) ([]yaml.Node, E
 	info := DefaultInfo()
 
 	if len(e.lambda.Names) > 2 {
-		info.Issue = "mapping expression take a maximum of 2 arguments"
+		info.Issue = yaml.NewIssue("mapping expression take a maximum of 2 arguments")
 		return nil, info, false
 	}
 	for i, n := range source {

--- a/dynaml/mapping_test.go
+++ b/dynaml/mapping_test.go
@@ -1,0 +1,33 @@
+package dynaml
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("mapping expressions", func() {
+	It("prints mapping expression", func() {
+		desc := MapExpr{
+			ReferenceExpr{[]string{"list"}},
+			ConcatenationExpr{
+				ReferenceExpr{[]string{"x"}},
+				StringExpr{".*"},
+			},
+		}.String()
+		Expect(desc).To(Equal("map[list|x \".*\"]"))
+	})
+
+	It("simplifies lambda mapping expression", func() {
+		desc := MapExpr{
+			ReferenceExpr{[]string{"list"}},
+			LambdaExpr{
+				[]string{"x"},
+				ConcatenationExpr{
+					ReferenceExpr{[]string{"x"}},
+					StringExpr{".*"},
+				},
+			},
+		}.String()
+		Expect(desc).To(Equal("map[list|x|->x \".*\"]"))
+	})
+})

--- a/dynaml/merge.go
+++ b/dynaml/merge.go
@@ -14,7 +14,7 @@ type MergeExpr struct {
 	KeyName  string
 }
 
-func (e MergeExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e MergeExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 	var info EvaluationInfo
 	if e.Redirect {
 		info.RedirectPath = e.Path
@@ -25,10 +25,12 @@ func (e MergeExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 	if ok {
 		info.Replace = e.Replace
 		info.Merged = true
+		info.Source = node.SourceName()
+		return node.Value(), info, ok
 	} else {
 		info.Issue = yaml.NewIssue("'%s' not found in any stub", strings.Join(e.Path, "."))
+		return nil, info, false
 	}
-	return node, info, ok
 }
 
 func (e MergeExpr) String() string {

--- a/dynaml/merge.go
+++ b/dynaml/merge.go
@@ -1,7 +1,6 @@
 package dynaml
 
 import (
-	"fmt"
 	"github.com/cloudfoundry-incubator/spiff/debug"
 	"github.com/cloudfoundry-incubator/spiff/yaml"
 	"strings"
@@ -27,7 +26,7 @@ func (e MergeExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 		info.Replace = e.Replace
 		info.Merged = true
 	} else {
-		info.Issue = fmt.Sprintf("'%s' not found in any stub", strings.Join(e.Path, "."))
+		info.Issue = yaml.NewIssue("'%s' not found in any stub", strings.Join(e.Path, "."))
 	}
 	return node, info, ok
 }

--- a/dynaml/merge_test.go
+++ b/dynaml/merge_test.go
@@ -22,7 +22,7 @@ var _ = Describe("merges", func() {
 
 			binding := FakeBinding{
 				FoundInStubs: map[string]yaml.Node{
-					"foo.bar": node(referencedNode),
+					"foo.bar": node(referencedNode, nil),
 				},
 			}
 
@@ -44,7 +44,7 @@ var _ = Describe("merges", func() {
 
 			binding := FakeBinding{
 				FoundInStubs: map[string]yaml.Node{
-					"foo.bar": node(referencedNode),
+					"foo.bar": node(referencedNode, nil),
 				},
 			}
 

--- a/dynaml/modulo.go
+++ b/dynaml/modulo.go
@@ -29,7 +29,7 @@ func (e ModuloExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) 
 	}
 
 	if bint == 0 {
-		info.Issue = "division by zero"
+		info.Issue = yaml.NewIssue("division by zero")
 		return nil, info, false
 	}
 	return node(aint % bint), info, true

--- a/dynaml/modulo.go
+++ b/dynaml/modulo.go
@@ -11,7 +11,7 @@ type ModuloExpr struct {
 	B Expression
 }
 
-func (e ModuloExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e ModuloExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 	resolved := true
 
 	aint, info, ok := ResolveIntegerExpressionOrPushEvaluation(&e.A, &resolved, nil, binding)
@@ -25,14 +25,14 @@ func (e ModuloExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) 
 	}
 
 	if !resolved {
-		return node(e), info, true
+		return e, info, true
 	}
 
 	if bint == 0 {
 		info.Issue = yaml.NewIssue("division by zero")
 		return nil, info, false
 	}
-	return node(aint % bint), info, true
+	return aint % bint, info, true
 }
 
 func (e ModuloExpr) String() string {

--- a/dynaml/multiplication.go
+++ b/dynaml/multiplication.go
@@ -2,8 +2,6 @@ package dynaml
 
 import (
 	"fmt"
-
-	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
 type MultiplicationExpr struct {
@@ -11,7 +9,7 @@ type MultiplicationExpr struct {
 	B Expression
 }
 
-func (e MultiplicationExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e MultiplicationExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 	resolved := true
 
 	aint, info, ok := ResolveIntegerExpressionOrPushEvaluation(&e.A, &resolved, nil, binding)
@@ -25,9 +23,9 @@ func (e MultiplicationExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo
 	}
 
 	if !resolved {
-		return node(e), info, true
+		return e, info, true
 	}
-	return node(aint * bint), info, true
+	return aint * bint, info, true
 }
 
 func (e MultiplicationExpr) String() string {

--- a/dynaml/nil.go
+++ b/dynaml/nil.go
@@ -1,13 +1,9 @@
 package dynaml
 
-import (
-	"github.com/cloudfoundry-incubator/spiff/yaml"
-)
-
 type NilExpr struct{}
 
-func (e NilExpr) Evaluate(Binding) (yaml.Node, EvaluationInfo, bool) {
-	return node(nil), DefaultInfo(), true
+func (e NilExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
+	return nil, DefaultInfo(), true
 }
 
 func (e NilExpr) String() string {

--- a/dynaml/node.go
+++ b/dynaml/node.go
@@ -1,9 +1,30 @@
 package dynaml
 
 import (
+	"strings"
+
 	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
-func node(val interface{}) yaml.Node {
-	return yaml.NewNode(val, "dynaml")
+func value(node yaml.Node) interface{} {
+	if node == nil {
+		return nil
+	}
+	return node.Value()
+}
+
+func node(val interface{}, src SourceProvider) yaml.Node {
+	source := ""
+
+	if src == nil || len(src.SourceName()) == 0 {
+		source = "dynaml"
+	} else {
+		if !strings.HasPrefix(src.SourceName(), "dynaml@") {
+			source = "dynaml@" + src.SourceName()
+		} else {
+			source = src.SourceName()
+		}
+	}
+
+	return yaml.NewNode(val, source)
 }

--- a/dynaml/not.go
+++ b/dynaml/not.go
@@ -4,25 +4,24 @@ import (
 	"fmt"
 
 	"github.com/cloudfoundry-incubator/spiff/debug"
-	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
 type NotExpr struct {
 	Expr Expression
 }
 
-func (e NotExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e NotExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 	resolved := true
 	v, info, ok := ResolveExpressionOrPushEvaluation(&e.Expr, &resolved, nil, binding)
 	if !ok {
 		return nil, info, false
 	}
 	if !resolved {
-		return node(e), info, true
+		return e, info, true
 	}
 
 	debug.Debug("NOT: %#v\n", v)
-	return node(!toBool(v)), info, true
+	return !toBool(v), info, true
 }
 
 func (e NotExpr) String() string {

--- a/dynaml/not.go
+++ b/dynaml/not.go
@@ -1,0 +1,30 @@
+package dynaml
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry-incubator/spiff/debug"
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+type NotExpr struct {
+	Expr Expression
+}
+
+func (e NotExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	resolved := true
+	v, info, ok := ResolveExpressionOrPushEvaluation(&e.Expr, &resolved, nil, binding)
+	if !ok {
+		return nil, info, false
+	}
+	if !resolved {
+		return node(e), info, true
+	}
+
+	debug.Debug("NOT: %#v\n", v)
+	return node(!toBool(v)), info, true
+}
+
+func (e NotExpr) String() string {
+	return fmt.Sprintf("!(%s)", e.Expr)
+}

--- a/dynaml/not_test.go
+++ b/dynaml/not_test.go
@@ -1,0 +1,36 @@
+package dynaml
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("logical and", func() {
+	Context("on boolean", func() {
+		It("not true = false", func() {
+			expr := NotExpr{
+				BooleanExpr{true},
+			}
+
+			Expect(expr).To(EvaluateAs(false, FakeBinding{}))
+		})
+
+		It("not false = true", func() {
+			expr := NotExpr{
+				BooleanExpr{false},
+			}
+
+			Expect(expr).To(EvaluateAs(true, FakeBinding{}))
+		})
+	})
+
+	Context("on integer", func() {
+		It("!=0 returns false", func() {
+			expr := NotExpr{
+				IntegerExpr{6},
+			}
+
+			Expect(expr).To(EvaluateAs(false, FakeBinding{}))
+		})
+	})
+})

--- a/dynaml/or.go
+++ b/dynaml/or.go
@@ -3,8 +3,6 @@ package dynaml
 import (
 	"fmt"
 	"reflect"
-
-	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
 type OrExpr struct {
@@ -12,13 +10,12 @@ type OrExpr struct {
 	B Expression
 }
 
-func (e OrExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e OrExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 	a, infoa, ok := e.A.Evaluate(binding)
 	if ok {
-		if reflect.DeepEqual(a.Value(), e.A) {
+		if reflect.DeepEqual(a, e.A) {
 			return nil, infoa, false
 		}
-
 		return a, infoa, true
 	}
 

--- a/dynaml/or_test.go
+++ b/dynaml/or_test.go
@@ -72,7 +72,7 @@ var _ = Describe("or", func() {
 
 			binding := FakeBinding{
 				FoundReferences: map[string]yaml.Node{
-					"foo": node(MergeExpr{}),
+					"foo": node(MergeExpr{}, nil),
 				},
 			}
 

--- a/dynaml/parser.go
+++ b/dynaml/parser.go
@@ -88,11 +88,18 @@ func buildExpression(grammar *DynamlGrammar, path []string, stubPath []string) E
 		case ruleReference, ruleFollowUpRef:
 			tokens.Push(ReferenceExpr{strings.Split(contents, ".")})
 
-		case ruleQualifiedExpression:
+		case ruleChained:
+		case ruleChainedQualifiedExpression:
 			ref := tokens.Pop()
 			expr := tokens.Pop()
 			tokens.Push(QualifiedExpr{expr, ref.(ReferenceExpr)})
-
+			
+		case ruleChainedCall:
+			tokens.Push(CallExpr{
+				Function:  tokens.Pop(),
+				Arguments: tokens.GetExpressionList(),
+			})
+			
 		case ruleInteger:
 			val, err := strconv.ParseInt(contents, 10, 64)
 			if err != nil {
@@ -176,11 +183,7 @@ func buildExpression(grammar *DynamlGrammar, path []string, stubPath []string) E
 			lhs := tokens.Pop()
 
 			tokens.Push(ModuloExpr{A: lhs, B: rhs})
-		case ruleCall:
-			tokens.Push(CallExpr{
-				Function:  tokens.Pop(),
-				Arguments: tokens.GetExpressionList(),
-			})
+			
 		case ruleName:
 			tokens.Push(nameHelper{name: contents})
 		case ruleNextName:

--- a/dynaml/parser.go
+++ b/dynaml/parser.go
@@ -62,6 +62,8 @@ func buildExpression(grammar *DynamlGrammar, path []string, stubPath []string) E
 		switch token.pegRule {
 		case ruleDynaml:
 			return tokens.Pop()
+		case ruleTemplate:
+			return TemplateExpr{}
 		case rulePrefer:
 			tokens.Push(PreferExpr{tokens.Pop()})
 		case ruleAuto:
@@ -114,6 +116,9 @@ func buildExpression(grammar *DynamlGrammar, path []string, stubPath []string) E
 		case ruleString:
 			val := strings.Replace(contents[1:len(contents)-1], `\"`, `"`, -1)
 			tokens.Push(StringExpr{val})
+
+		case ruleSubstitution:
+			tokens.Push(SubstitutionExpr{Template: tokens.Pop()})
 
 		case ruleConditional:
 			fhs := tokens.Pop()

--- a/dynaml/parser.go
+++ b/dynaml/parser.go
@@ -147,10 +147,8 @@ func buildExpression(grammar *DynamlGrammar, path []string, stubPath []string) E
 
 		case ruleMapping:
 			rhs := tokens.Pop()
-			names := tokens.PopNameList().list
-			reverse(names)
 			lhs := tokens.Pop()
-			tokens.Push(MapExpr{A: lhs, Names: names, B: rhs})
+			tokens.Push(MapExpr{Lambda: rhs, A: lhs})
 
 		case ruleLambda:
 

--- a/dynaml/parser.go
+++ b/dynaml/parser.go
@@ -6,12 +6,11 @@ import (
 	"strings"
 
 	"github.com/cloudfoundry-incubator/spiff/debug"
-	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
 type helperNode struct{}
 
-func (e helperNode) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e helperNode) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 	panic("not intended to be evaluated")
 }
 

--- a/dynaml/parser.go
+++ b/dynaml/parser.go
@@ -93,13 +93,13 @@ func buildExpression(grammar *DynamlGrammar, path []string, stubPath []string) E
 			ref := tokens.Pop()
 			expr := tokens.Pop()
 			tokens.Push(QualifiedExpr{expr, ref.(ReferenceExpr)})
-			
+
 		case ruleChainedCall:
 			tokens.Push(CallExpr{
 				Function:  tokens.Pop(),
 				Arguments: tokens.GetExpressionList(),
 			})
-			
+
 		case ruleInteger:
 			val, err := strconv.ParseInt(contents, 10, 64)
 			if err != nil {
@@ -183,7 +183,7 @@ func buildExpression(grammar *DynamlGrammar, path []string, stubPath []string) E
 			lhs := tokens.Pop()
 
 			tokens.Push(ModuloExpr{A: lhs, B: rhs})
-			
+
 		case ruleName:
 			tokens.Push(nameHelper{name: contents})
 		case ruleNextName:

--- a/dynaml/parser_test.go
+++ b/dynaml/parser_test.go
@@ -374,8 +374,10 @@ var _ = Describe("parsing", func() {
 				`map[list|x|->x]`,
 				MapExpr{
 					ReferenceExpr{[]string{"list"}},
-					[]string{"x"},
-					ReferenceExpr{[]string{"x"}},
+					LambdaExpr{
+						[]string{"x"},
+						ReferenceExpr{[]string{"x"}},
+					},
 				},
 			)
 		})
@@ -385,8 +387,10 @@ var _ = Describe("parsing", func() {
 				`map[list|x,y|->x]`,
 				MapExpr{
 					ReferenceExpr{[]string{"list"}},
-					[]string{"y", "x"},
-					ReferenceExpr{[]string{"x"}},
+					LambdaExpr{
+						[]string{"x", "y"},
+						ReferenceExpr{[]string{"x"}},
+					},
 				},
 			)
 		})
@@ -396,10 +400,40 @@ var _ = Describe("parsing", func() {
 				`map[list|x|->x ".*"]`,
 				MapExpr{
 					ReferenceExpr{[]string{"list"}},
-					[]string{"x"},
-					ConcatenationExpr{
-						ReferenceExpr{[]string{"x"}},
-						StringExpr{".*"},
+					LambdaExpr{
+						[]string{"x"},
+						ConcatenationExpr{
+							ReferenceExpr{[]string{"x"}},
+							StringExpr{".*"},
+						},
+					},
+				},
+			)
+		})
+
+		It("parses mapping expression", func() {
+			parsesAs(
+				`map[list|mappings.a]`,
+				MapExpr{
+					ReferenceExpr{[]string{"list"}},
+					ReferenceExpr{
+						[]string{"mappings", "a"},
+					},
+				},
+			)
+		})
+
+		It("parses complex mapping expression", func() {
+			parsesAs(
+				`map[list|lambda |x|->x ".*"]`,
+				MapExpr{
+					ReferenceExpr{[]string{"list"}},
+					LambdaExpr{
+						[]string{"x"},
+						ConcatenationExpr{
+							ReferenceExpr{[]string{"x"}},
+							StringExpr{".*"},
+						},
 					},
 				},
 			)

--- a/dynaml/parser_test.go
+++ b/dynaml/parser_test.go
@@ -479,6 +479,88 @@ var _ = Describe("parsing", func() {
 			)
 		})
 	})
+	
+	Describe("chained calls and references", func() {
+		It("parses reference based chains", func() {
+			parsesAs(
+				`a.b(1)(2).c(3).e.f(4).g`,
+				QualifiedExpr{
+					CallExpr{
+						QualifiedExpr{
+							CallExpr{
+								QualifiedExpr{
+									CallExpr{
+										CallExpr{
+											ReferenceExpr{[]string{"a","b"}},
+											[]Expression{
+												IntegerExpr{1},
+											},
+										},
+										[]Expression{
+											IntegerExpr{2},
+										},
+									},
+									ReferenceExpr{[]string{"c"}},
+								},
+								[]Expression{
+									IntegerExpr{3},
+								},
+							},
+							ReferenceExpr{[]string{"e","f"}},
+						},
+						[]Expression{
+							IntegerExpr{4},
+						},
+					},
+					ReferenceExpr{[]string{"g"}},
+				},
+			)
+		})
+		
+		It("parses list based chains", func() {
+			parsesAs(
+				`[1,2].a(1)(2).c(3).e.f(4).g`,
+				QualifiedExpr{
+					CallExpr{
+						QualifiedExpr{
+							CallExpr{
+								QualifiedExpr{
+									CallExpr{
+										CallExpr{
+											QualifiedExpr{
+												ListExpr{
+													[]Expression{
+														IntegerExpr{1},
+														IntegerExpr{2},
+													},
+												},
+												ReferenceExpr{[]string{"a"}},
+											},
+											[]Expression{
+												IntegerExpr{1},
+											},
+										},
+										[]Expression{
+											IntegerExpr{2},
+										},
+									},
+									ReferenceExpr{[]string{"c"}},
+								},
+								[]Expression{
+									IntegerExpr{3},
+								},
+							},
+							ReferenceExpr{[]string{"e","f"}},
+						},
+						[]Expression{
+							IntegerExpr{4},
+						},
+					},
+					ReferenceExpr{[]string{"g"}},
+				},
+			)
+		})
+	})
 })
 
 func parsesAs(source string, expr Expression, path ...string) {

--- a/dynaml/parser_test.go
+++ b/dynaml/parser_test.go
@@ -479,7 +479,7 @@ var _ = Describe("parsing", func() {
 			)
 		})
 	})
-	
+
 	Describe("chained calls and references", func() {
 		It("parses reference based chains", func() {
 			parsesAs(
@@ -491,7 +491,7 @@ var _ = Describe("parsing", func() {
 								QualifiedExpr{
 									CallExpr{
 										CallExpr{
-											ReferenceExpr{[]string{"a","b"}},
+											ReferenceExpr{[]string{"a", "b"}},
 											[]Expression{
 												IntegerExpr{1},
 											},
@@ -506,7 +506,7 @@ var _ = Describe("parsing", func() {
 									IntegerExpr{3},
 								},
 							},
-							ReferenceExpr{[]string{"e","f"}},
+							ReferenceExpr{[]string{"e", "f"}},
 						},
 						[]Expression{
 							IntegerExpr{4},
@@ -516,7 +516,7 @@ var _ = Describe("parsing", func() {
 				},
 			)
 		})
-		
+
 		It("parses list based chains", func() {
 			parsesAs(
 				`[1,2].a(1)(2).c(3).e.f(4).g`,
@@ -550,7 +550,7 @@ var _ = Describe("parsing", func() {
 									IntegerExpr{3},
 								},
 							},
-							ReferenceExpr{[]string{"e","f"}},
+							ReferenceExpr{[]string{"e", "f"}},
 						},
 						[]Expression{
 							IntegerExpr{4},

--- a/dynaml/prefer.go
+++ b/dynaml/prefer.go
@@ -2,19 +2,17 @@ package dynaml
 
 import (
 	"fmt"
-
-	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
 type PreferExpr struct {
 	expression Expression
 }
 
-func (e PreferExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e PreferExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 
-	node, info, ok := e.expression.Evaluate(binding)
+	val, info, ok := e.expression.Evaluate(binding)
 	info.Preferred = true
-	return node, info, ok
+	return val, info, ok
 }
 
 func (e PreferExpr) String() string {

--- a/dynaml/qualified_expression.go
+++ b/dynaml/qualified_expression.go
@@ -1,0 +1,33 @@
+package dynaml
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry-incubator/spiff/debug"
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+type QualifiedExpr struct {
+	Expression Expression
+	Reference  ReferenceExpr
+}
+
+func (e QualifiedExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+
+	root, info, ok := e.Expression.Evaluate(binding)
+	if !ok {
+		return nil, info, false
+	}
+	if !isResolved(root) {
+		return node(e), info, true
+	}
+
+	debug.Debug("qualified reference: %v\n", e.Reference.Path)
+	return e.Reference.find(func(end int, path []string) (yaml.Node, bool) {
+		return yaml.Find(root, e.Reference.Path[0:end+1]...)
+	})
+}
+
+func (e QualifiedExpr) String() string {
+	return fmt.Sprintf("(%s).%s", e.Expression, e.Reference)
+}

--- a/dynaml/qualified_expression.go
+++ b/dynaml/qualified_expression.go
@@ -12,20 +12,20 @@ type QualifiedExpr struct {
 	Reference  ReferenceExpr
 }
 
-func (e QualifiedExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e QualifiedExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 
 	root, info, ok := e.Expression.Evaluate(binding)
 	if !ok {
 		return nil, info, false
 	}
-	if !isResolved(root) {
-		return node(e), info, true
+	if !isResolvedValue(root) {
+		return e, info, true
 	}
 
 	debug.Debug("qualified reference: %v\n", e.Reference.Path)
 	return e.Reference.find(func(end int, path []string) (yaml.Node, bool) {
-		return yaml.Find(root, e.Reference.Path[0:end+1]...)
-	})
+		return yaml.Find(node(root, nil), e.Reference.Path[0:end+1]...)
+	}, binding)
 }
 
 func (e QualifiedExpr) String() string {

--- a/dynaml/range.go
+++ b/dynaml/range.go
@@ -11,7 +11,7 @@ type RangeExpr struct {
 	End   Expression
 }
 
-func (e RangeExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e RangeExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 	resolved := true
 
 	start, info, ok := ResolveIntegerExpressionOrPushEvaluation(&e.Start, &resolved, nil, binding)
@@ -23,7 +23,7 @@ func (e RangeExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 		return nil, info, false
 	}
 	if !resolved {
-		return node(e), info, true
+		return e, info, true
 	}
 
 	nodes := []yaml.Node{}
@@ -32,10 +32,10 @@ func (e RangeExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
 		delta = -1
 	}
 	for i := start; i*delta <= end*delta; i += delta {
-		nodes = append(nodes, node(i))
+		nodes = append(nodes, node(i, binding))
 	}
 
-	return node(nodes), info, true
+	return nodes, info, true
 }
 
 func (e RangeExpr) String() string {

--- a/dynaml/range.go
+++ b/dynaml/range.go
@@ -1,0 +1,43 @@
+package dynaml
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+type RangeExpr struct {
+	Start Expression
+	End   Expression
+}
+
+func (e RangeExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	resolved := true
+
+	start, info, ok := ResolveIntegerExpressionOrPushEvaluation(&e.Start, &resolved, nil, binding)
+	if !ok {
+		return nil, info, false
+	}
+	end, info, ok := ResolveIntegerExpressionOrPushEvaluation(&e.End, &resolved, &info, binding)
+	if !ok {
+		return nil, info, false
+	}
+	if !resolved {
+		return node(e), info, true
+	}
+
+	nodes := []yaml.Node{}
+	delta := int64(1)
+	if start > end {
+		delta = -1
+	}
+	for i := start; i*delta <= end*delta; i += delta {
+		nodes = append(nodes, node(i))
+	}
+
+	return node(nodes), info, true
+}
+
+func (e RangeExpr) String() string {
+	return fmt.Sprintf("[%s..%s]", e.Start, e.End)
+}

--- a/dynaml/range_test.go
+++ b/dynaml/range_test.go
@@ -1,0 +1,46 @@
+package dynaml
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+var _ = Describe("integer range", func() {
+	It("evaluates an increasing range", func() {
+		expr := RangeExpr{
+			IntegerExpr{1},
+			IntegerExpr{3},
+		}
+
+		Expect(expr).To(EvaluateAs([]yaml.Node{node(1), node(2), node(3)}, FakeBinding{}))
+	})
+
+	It("evaluates a decreasing range", func() {
+		expr := RangeExpr{
+			IntegerExpr{1},
+			IntegerExpr{-1},
+		}
+
+		Expect(expr).To(EvaluateAs([]yaml.Node{node(1), node(0), node(-1)}, FakeBinding{}))
+	})
+
+	It("evaluates a single element range", func() {
+		expr := RangeExpr{
+			IntegerExpr{1},
+			IntegerExpr{1},
+		}
+
+		Expect(expr).To(EvaluateAs([]yaml.Node{node(1)}, FakeBinding{}))
+	})
+
+	It("evaluates to failure", func() {
+		expr := RangeExpr{
+			StringExpr{"foo"},
+			IntegerExpr{1},
+		}
+
+		Expect(expr).To(FailToEvaluate(FakeBinding{}))
+	})
+})

--- a/dynaml/range_test.go
+++ b/dynaml/range_test.go
@@ -14,7 +14,7 @@ var _ = Describe("integer range", func() {
 			IntegerExpr{3},
 		}
 
-		Expect(expr).To(EvaluateAs([]yaml.Node{node(1), node(2), node(3)}, FakeBinding{}))
+		Expect(expr).To(EvaluateAs([]yaml.Node{node(1, nil), node(2, nil), node(3, nil)}, FakeBinding{}))
 	})
 
 	It("evaluates a decreasing range", func() {
@@ -23,7 +23,7 @@ var _ = Describe("integer range", func() {
 			IntegerExpr{-1},
 		}
 
-		Expect(expr).To(EvaluateAs([]yaml.Node{node(1), node(0), node(-1)}, FakeBinding{}))
+		Expect(expr).To(EvaluateAs([]yaml.Node{node(1, nil), node(0, nil), node(-1, nil)}, FakeBinding{}))
 	})
 
 	It("evaluates a single element range", func() {
@@ -32,7 +32,7 @@ var _ = Describe("integer range", func() {
 			IntegerExpr{1},
 		}
 
-		Expect(expr).To(EvaluateAs([]yaml.Node{node(1)}, FakeBinding{}))
+		Expect(expr).To(EvaluateAs([]yaml.Node{node(1, nil)}, FakeBinding{}))
 	})
 
 	It("evaluates to failure", func() {

--- a/dynaml/read.go
+++ b/dynaml/read.go
@@ -1,0 +1,81 @@
+package dynaml
+
+import (
+	"io/ioutil"
+	"path"
+	"strings"
+
+	"github.com/cloudfoundry-incubator/spiff/debug"
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+var fileCache = map[string][]byte{}
+
+func func_read(arguments []interface{}, binding Binding) (interface{}, EvaluationInfo, bool) {
+	info := DefaultInfo()
+
+	if len(arguments) > 2 {
+		info.Issue = yaml.NewIssue("read takes a maximum of two arguments")
+		return nil, info, false
+	}
+
+	file, ok := arguments[0].(string)
+	if !ok {
+		info.Issue = yaml.NewIssue("string value requiredfor file path")
+		return nil, info, false
+	}
+
+	t := "text"
+	if strings.HasSuffix(file, ".yml") {
+		t = "yaml"
+	}
+	if len(arguments) > 1 {
+		t, ok = arguments[1].(string)
+		if !ok {
+			info.Issue = yaml.NewIssue("string value required for type")
+			return nil, info, false
+		}
+
+	}
+
+	var err error
+
+	data := fileCache[file]
+	if data == nil {
+		debug.Debug("reading %s file %s\n", t, file)
+		data, err = ioutil.ReadFile(file)
+		if err != nil {
+			info.Issue = yaml.NewIssue("error reading [%s]: %s", path.Clean(file), err)
+			return nil, info, false
+		}
+		fileCache[file] = data
+	}
+
+	switch t {
+	case "yaml":
+		node, err := yaml.Parse(file, data)
+		if err != nil {
+			info.Issue = yaml.NewIssue("error parsing stub [%s]: %s", path.Clean(file), err)
+			return nil, info, false
+		}
+		debug.Debug("resolving yaml file\n")
+		result, state := binding.Flow(node, false)
+		if state != nil {
+			debug.Debug("resolving yaml file failed: " + state.Error())
+			info.Issue = state.Issue("yaml file resolution failed")
+			return nil, info, true
+		}
+		debug.Debug("resolving yaml file succeeded")
+		info.Source = file
+		return result.Value(), info, true
+
+	case "text":
+		info.Source = file
+		return string(data), info, true
+
+	default:
+		info.Issue = yaml.NewIssue("invalid file type [%s] %s", path.Clean(file), t)
+		return nil, info, false
+	}
+
+}

--- a/dynaml/reference.go
+++ b/dynaml/reference.go
@@ -1,7 +1,6 @@
 package dynaml
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/cloudfoundry-incubator/spiff/debug"
@@ -39,7 +38,7 @@ func (e ReferenceExpr) find(f func(int, []string) (yaml.Node, bool)) (yaml.Node,
 
 		debug.Debug("  %d: %v %#v\n", i, ok, step)
 		if !ok {
-			info.Issue = fmt.Sprintf("'%s' not found", strings.Join(e.Path, "."))
+			info.Issue = yaml.NewIssue("'%s' not found", strings.Join(e.Path, "."))
 			return nil, info, false
 		}
 

--- a/dynaml/reference_test.go
+++ b/dynaml/reference_test.go
@@ -14,8 +14,8 @@ var _ = Describe("references", func() {
 
 			binding := FakeBinding{
 				FoundReferences: map[string]yaml.Node{
-					"foo":     node(nil),
-					"foo.bar": node(42),
+					"foo":     node(nil, nil),
+					"foo.bar": node(42, nil),
 				},
 			}
 
@@ -28,7 +28,7 @@ var _ = Describe("references", func() {
 
 				binding := FakeBinding{
 					FoundReferences: map[string]yaml.Node{
-						"foo": node(MergeExpr{}),
+						"foo": node(MergeExpr{}, nil),
 					},
 				}
 

--- a/dynaml/split.go
+++ b/dynaml/split.go
@@ -1,0 +1,34 @@
+package dynaml
+
+import (
+	"strings"
+
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+func func_split(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	info := DefaultInfo()
+
+	if len(arguments) != 2 {
+		info.Issue = "split takes exactly 2 arguments"
+		return nil, info, false
+	}
+
+	sep, ok := arguments[0].(string)
+	if !ok {
+		info.Issue = "first argument for split must be a string"
+		return nil, info, false
+	}
+	str, ok := arguments[1].(string)
+	if !ok {
+		info.Issue = "second argument for split must be a string"
+		return nil, info, false
+	}
+
+	array := strings.Split(str, sep)
+	result := make([]yaml.Node, len(array))
+	for i, e := range array {
+		result[i] = node(e)
+	}
+	return node(result), info, true
+}

--- a/dynaml/split.go
+++ b/dynaml/split.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
-func func_split(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func func_split(arguments []interface{}, binding Binding) (interface{}, EvaluationInfo, bool) {
 	info := DefaultInfo()
 
 	if len(arguments) != 2 {
@@ -28,7 +28,7 @@ func func_split(arguments []interface{}, binding Binding) (yaml.Node, Evaluation
 	array := strings.Split(str, sep)
 	result := make([]yaml.Node, len(array))
 	for i, e := range array {
-		result[i] = node(e)
+		result[i] = node(e, binding)
 	}
-	return node(result), info, true
+	return result, info, true
 }

--- a/dynaml/split.go
+++ b/dynaml/split.go
@@ -10,18 +10,18 @@ func func_split(arguments []interface{}, binding Binding) (yaml.Node, Evaluation
 	info := DefaultInfo()
 
 	if len(arguments) != 2 {
-		info.Issue = "split takes exactly 2 arguments"
+		info.Issue = yaml.NewIssue("split takes exactly 2 arguments")
 		return nil, info, false
 	}
 
 	sep, ok := arguments[0].(string)
 	if !ok {
-		info.Issue = "first argument for split must be a string"
+		info.Issue = yaml.NewIssue("first argument for split must be a string")
 		return nil, info, false
 	}
 	str, ok := arguments[1].(string)
 	if !ok {
-		info.Issue = "second argument for split must be a string"
+		info.Issue = yaml.NewIssue("second argument for split must be a string")
 		return nil, info, false
 	}
 

--- a/dynaml/static_ips.go
+++ b/dynaml/static_ips.go
@@ -1,7 +1,6 @@
 package dynaml
 
 import (
-	"fmt"
 	"net"
 	"strings"
 
@@ -64,7 +63,7 @@ func generateStaticIPs(binding Binding, indices []int) (yaml.Node, EvaluationInf
 	}
 
 	if len(ips) < instanceCount {
-		info.Issue = fmt.Sprintf("too less static IPs for %d instances", instanceCount)
+		info.Issue = yaml.NewIssue("too less static IPs for %d instances", instanceCount)
 		return nil, info, false
 	}
 
@@ -89,7 +88,7 @@ func findStaticIPRanges(binding Binding) ([]string, EvaluationInfo, bool) {
 
 	networkName, ok := nearestNetworkName.Value().(string)
 	if !ok {
-		info.Issue = "name field must be string"
+		info.Issue = yaml.NewIssue("name field must be string")
 		return nil, info, false
 	}
 
@@ -105,7 +104,7 @@ func findStaticIPRanges(binding Binding) ([]string, EvaluationInfo, bool) {
 
 	subnetsList, ok := subnets.Value().([]yaml.Node)
 	if !ok {
-		info.Issue = "subnets field must be a list"
+		info.Issue = yaml.NewIssue("subnets field must be a list")
 		return nil, info, false
 	}
 
@@ -114,20 +113,20 @@ func findStaticIPRanges(binding Binding) ([]string, EvaluationInfo, bool) {
 	for _, subnet := range subnetsList {
 		subnetMap, ok := subnet.Value().(map[string]yaml.Node)
 		if !ok {
-			info.Issue = "subnet must be a map"
+			info.Issue = yaml.NewIssue("subnet must be a map")
 			return nil, info, false
 		}
 
 		static, ok := subnetMap["static"]
 
 		if !ok {
-			info.Issue = fmt.Sprintf("no static ips for network %s", networkName)
+			info.Issue = yaml.NewIssue("no static ips for network %s", networkName)
 			return nil, info, false
 		}
 
 		staticList, ok := static.Value().([]yaml.Node)
 		if !ok {
-			info.Issue = fmt.Sprintf("static ips for network %s must be a list", networkName)
+			info.Issue = yaml.NewIssue("static ips for network %s must be a list", networkName)
 			return nil, info, false
 		}
 
@@ -136,7 +135,7 @@ func findStaticIPRanges(binding Binding) ([]string, EvaluationInfo, bool) {
 		for i, r := range staticList {
 			ipsString, ok := r.Value().(string)
 			if !ok {
-				info.Issue = fmt.Sprintf("invalid entry for static ips for network %s", networkName)
+				info.Issue = yaml.NewIssue("invalid entry for static ips for network %s", networkName)
 				return nil, info, false
 			}
 

--- a/dynaml/static_ips.go
+++ b/dynaml/static_ips.go
@@ -12,7 +12,7 @@ var (
 	refInstances = ReferenceExpr{[]string{"instances"}}
 )
 
-func func_static_ips(arguments []Expression, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func func_static_ips(arguments []Expression, binding Binding) (interface{}, EvaluationInfo, bool) {
 
 	indices := make([]int, len(arguments))
 	for i, arg := range arguments {
@@ -21,7 +21,7 @@ func func_static_ips(arguments []Expression, binding Binding) (yaml.Node, Evalua
 			return nil, info, false
 		}
 
-		index64, ok := index.Value().(int64)
+		index64, ok := index.(int64)
 		if !ok {
 			return nil, info, false
 		}
@@ -31,7 +31,7 @@ func func_static_ips(arguments []Expression, binding Binding) (yaml.Node, Evalua
 	return generateStaticIPs(binding, indices)
 }
 
-func generateStaticIPs(binding Binding, indices []int) (yaml.Node, EvaluationInfo, bool) {
+func generateStaticIPs(binding Binding, indices []int) (interface{}, EvaluationInfo, bool) {
 	info := DefaultInfo()
 
 	if len(indices) == 0 {
@@ -59,7 +59,7 @@ func generateStaticIPs(binding Binding, indices []int) (yaml.Node, EvaluationInf
 			return nil, info, false
 		}
 
-		ips = append(ips, node(ipPool[i].String()))
+		ips = append(ips, node(ipPool[i].String(), binding))
 	}
 
 	if len(ips) < instanceCount {
@@ -67,7 +67,7 @@ func generateStaticIPs(binding Binding, indices []int) (yaml.Node, EvaluationInf
 		return nil, info, false
 	}
 
-	return node(ips[:instanceCount]), info, true
+	return ips[:instanceCount], info, true
 }
 
 func findInstanceCount(binding Binding) (*int64, EvaluationInfo, bool) {
@@ -76,7 +76,7 @@ func findInstanceCount(binding Binding) (*int64, EvaluationInfo, bool) {
 		return nil, info, false
 	}
 
-	instances, ok := nearestInstances.Value().(int64)
+	instances, ok := nearestInstances.(int64)
 	return &instances, info, ok
 }
 
@@ -86,7 +86,7 @@ func findStaticIPRanges(binding Binding) ([]string, EvaluationInfo, bool) {
 		return nil, info, found
 	}
 
-	networkName, ok := nearestNetworkName.Value().(string)
+	networkName, ok := nearestNetworkName.(string)
 	if !ok {
 		info.Issue = yaml.NewIssue("name field must be string")
 		return nil, info, false
@@ -102,7 +102,7 @@ func findStaticIPRanges(binding Binding) ([]string, EvaluationInfo, bool) {
 		return nil, info, true
 	}
 
-	subnetsList, ok := subnets.Value().([]yaml.Node)
+	subnetsList, ok := subnets.([]yaml.Node)
 	if !ok {
 		info.Issue = yaml.NewIssue("subnets field must be a list")
 		return nil, info, false

--- a/dynaml/string.go
+++ b/dynaml/string.go
@@ -2,16 +2,14 @@ package dynaml
 
 import (
 	"fmt"
-
-	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
 type StringExpr struct {
 	Value string
 }
 
-func (e StringExpr) Evaluate(Binding) (yaml.Node, EvaluationInfo, bool) {
-	return node(e.Value), DefaultInfo(), true
+func (e StringExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
+	return e.Value, DefaultInfo(), true
 }
 
 func (e StringExpr) String() string {

--- a/dynaml/subtraction.go
+++ b/dynaml/subtraction.go
@@ -40,9 +40,9 @@ func (e SubtractionExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, b
 		if ip != nil {
 			return node(IPAdd(ip, -bint).String()), info, true
 		}
-		info.Issue = "string argument for MINUS must be an IP address"
+		info.Issue = yaml.NewIssue("string argument for MINUS must be an IP address")
 	} else {
-		info.Issue = "first argument of MINUS must be IP address or integer"
+		info.Issue = yaml.NewIssue("first argument of MINUS must be IP address or integer")
 	}
 	return nil, info, false
 }

--- a/dynaml/subtraction.go
+++ b/dynaml/subtraction.go
@@ -12,7 +12,7 @@ type SubtractionExpr struct {
 	B Expression
 }
 
-func (e SubtractionExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func (e SubtractionExpr) Evaluate(binding Binding) (interface{}, EvaluationInfo, bool) {
 	resolved := true
 
 	a, info, ok := ResolveExpressionOrPushEvaluation(&e.A, &resolved, nil, binding)
@@ -26,19 +26,19 @@ func (e SubtractionExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, b
 	}
 
 	if !resolved {
-		return node(e), info, true
+		return e, info, true
 	}
 
 	aint, ok := a.(int64)
 	if ok {
-		return node(aint - bint), info, true
+		return aint - bint, info, true
 	}
 
 	str, ok := a.(string)
 	if ok {
 		ip := net.ParseIP(str)
 		if ip != nil {
-			return node(IPAdd(ip, -bint).String()), info, true
+			return IPAdd(ip, -bint).String(), info, true
 		}
 		info.Issue = yaml.NewIssue("string argument for MINUS must be an IP address")
 	} else {

--- a/dynaml/template.go
+++ b/dynaml/template.go
@@ -1,0 +1,66 @@
+package dynaml
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry-incubator/spiff/debug"
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+type TemplateExpr struct {
+}
+
+func (e TemplateExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	info := DefaultInfo()
+	info.Issue = yaml.NewIssue("&template only usable to declare templates")
+	return nil, info, false
+}
+
+func (e TemplateExpr) String() string {
+	return fmt.Sprintf("&template")
+}
+
+type SubstitutionExpr struct {
+	Template Expression
+	Node     yaml.Node
+}
+
+func (e SubstitutionExpr) Evaluate(binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	if e.Node == nil {
+		debug.Debug("evaluating expression to determine template\n")
+		n, info, ok := e.Template.Evaluate(binding)
+		if !ok || isExpression((n)) {
+			return node(e), info, ok
+		}
+		val, ok := n.Value().(TemplateValue)
+		if !ok {
+			info.Issue = yaml.NewIssue("template value required")
+			return nil, info, false
+		} else {
+			e.Node = val.Prepared
+		}
+	}
+	debug.Debug("resolving template\n")
+	result, state := binding.Flow(e.Node, false)
+	info := DefaultInfo()
+	if state != nil {
+		debug.Debug("resolving template failed: " + state.Error())
+		info.Issue = state.Issue("template resolution failed")
+		return node(e), info, true
+	}
+	debug.Debug("resolving template succeeded")
+	return result, info, true
+}
+
+func (e SubstitutionExpr) String() string {
+	return fmt.Sprintf("*(%s)", e.Template)
+}
+
+type TemplateValue struct {
+	Prepared yaml.Node
+	Orig     yaml.Node
+}
+
+func (e TemplateValue) MarshalYAML() (tag string, value interface{}) {
+	return e.Orig.MarshalYAML()
+}

--- a/dynaml/trim.go
+++ b/dynaml/trim.go
@@ -1,0 +1,48 @@
+package dynaml
+
+import (
+	"strings"
+
+	"github.com/cloudfoundry-incubator/spiff/yaml"
+)
+
+func func_trim(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+	info := DefaultInfo()
+	ok := true
+
+	if len(arguments) > 2 {
+		info.Issue = "split takes one or two arguments"
+		return nil, info, false
+	}
+
+	cutset := " \t"
+	if len(arguments) == 2 {
+		cutset, ok = arguments[1].(string)
+		if !ok {
+			info.Issue = "second argument of split must be a string"
+			return nil, info, false
+		}
+	}
+	var result interface{}
+	switch v := arguments[0].(type) {
+	case string:
+		result = strings.Trim(v, cutset)
+	case []yaml.Node:
+		list := make([]yaml.Node, len(v))
+		for i, e := range v {
+			t, ok := e.Value().(string)
+			if !ok {
+				info.Issue = "list elements must be strings to be trimmed"
+				return nil, info, false
+			}
+			t = strings.Trim(t, cutset)
+			list[i] = node(t)
+		}
+		result = list
+	default:
+		info.Issue = "trim accepts only a string or list"
+		return nil, info, false
+	}
+
+	return node(result), info, true
+}

--- a/dynaml/trim.go
+++ b/dynaml/trim.go
@@ -11,7 +11,7 @@ func func_trim(arguments []interface{}, binding Binding) (yaml.Node, EvaluationI
 	ok := true
 
 	if len(arguments) > 2 {
-		info.Issue = "split takes one or two arguments"
+		info.Issue = yaml.NewIssue("split takes one or two arguments")
 		return nil, info, false
 	}
 
@@ -19,7 +19,7 @@ func func_trim(arguments []interface{}, binding Binding) (yaml.Node, EvaluationI
 	if len(arguments) == 2 {
 		cutset, ok = arguments[1].(string)
 		if !ok {
-			info.Issue = "second argument of split must be a string"
+			info.Issue = yaml.NewIssue("second argument of split must be a string")
 			return nil, info, false
 		}
 	}
@@ -32,7 +32,7 @@ func func_trim(arguments []interface{}, binding Binding) (yaml.Node, EvaluationI
 		for i, e := range v {
 			t, ok := e.Value().(string)
 			if !ok {
-				info.Issue = "list elements must be strings to be trimmed"
+				info.Issue = yaml.NewIssue("list elements must be strings to be trimmed")
 				return nil, info, false
 			}
 			t = strings.Trim(t, cutset)
@@ -40,7 +40,7 @@ func func_trim(arguments []interface{}, binding Binding) (yaml.Node, EvaluationI
 		}
 		result = list
 	default:
-		info.Issue = "trim accepts only a string or list"
+		info.Issue = yaml.NewIssue("trim accepts only a string or list")
 		return nil, info, false
 	}
 

--- a/dynaml/trim.go
+++ b/dynaml/trim.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
-func func_trim(arguments []interface{}, binding Binding) (yaml.Node, EvaluationInfo, bool) {
+func func_trim(arguments []interface{}, binding Binding) (interface{}, EvaluationInfo, bool) {
 	info := DefaultInfo()
 	ok := true
 
@@ -36,7 +36,7 @@ func func_trim(arguments []interface{}, binding Binding) (yaml.Node, EvaluationI
 				return nil, info, false
 			}
 			t = strings.Trim(t, cutset)
-			list[i] = node(t)
+			list[i] = node(t, binding)
 		}
 		result = list
 	default:
@@ -44,5 +44,5 @@ func func_trim(arguments []interface{}, binding Binding) (yaml.Node, EvaluationI
 		return nil, info, false
 	}
 
-	return node(result), info, true
+	return result, info, true
 }

--- a/dynaml/unresolved_check.go
+++ b/dynaml/unresolved_check.go
@@ -40,7 +40,7 @@ func (e UnresolvedNodes) Issue(message string) yaml.Issue {
 			node.SourceName(),
 			strings.Join(node.Context, "."),
 			strings.Join(node.Path, "."),
-			message,
+			msg,
 		)
 		issue.Issue = message
 		result.Nested = append(result.Nested, issue)

--- a/dynaml/unresolved_check.go
+++ b/dynaml/unresolved_check.go
@@ -148,11 +148,11 @@ func addContext(context []string, step string) []string {
 	return append(dup, step)
 }
 
-func isExpression(node yaml.Node) bool {
-	if node == nil {
+func isExpression(val interface{}) bool {
+	if val == nil {
 		return false
 	}
-	_, ok := node.Value().(Expression)
+	_, ok := val.(Expression)
 	return ok
 }
 
@@ -175,21 +175,25 @@ func isLocallyResolved(node yaml.Node) bool {
 }
 
 func isResolved(node yaml.Node) bool {
-	if node == nil {
+	return node == nil || isResolvedValue(node.Value())
+}
+
+func isResolvedValue(val interface{}) bool {
+	if val == nil {
 		return true
 	}
-	switch node.Value().(type) {
+	switch v := val.(type) {
 	case Expression:
 		return false
 	case []yaml.Node:
-		for _, n := range node.Value().([]yaml.Node) {
+		for _, n := range v {
 			if !isResolved(n) {
 				return false
 			}
 		}
 		return true
 	case map[string]yaml.Node:
-		for _, n := range node.Value().(map[string]yaml.Node) {
+		for _, n := range v {
 			if !isResolved(n) {
 				return false
 			}
@@ -197,7 +201,7 @@ func isResolved(node yaml.Node) bool {
 		return true
 
 	case string:
-		if yaml.EmbeddedDynaml(node) != nil {
+		if yaml.EmbeddedDynaml(node(val, nil)) != nil {
 			return false
 		}
 		return true

--- a/flow/cascade_test.go
+++ b/flow/cascade_test.go
@@ -321,6 +321,56 @@ values:
 `)
 				Expect(template).To(CascadeAs(resolved, source))
 			})
+
+			It("supports currying", func() {
+				source := parseYAML(`
+---
+mult: (( lambda |x,y|-> x * y ))
+mult2: (( .mult(2) ))
+values:
+  value: (( .mult2(5) ))
+`)
+
+				resolved := parseYAML(`
+---
+values:
+  value: 10
+`)
+				Expect(template).To(CascadeAs(resolved, source))
+			})
+
+			It("supports call chaining", func() {
+				source := parseYAML(`
+---
+mult: (( lambda |x,y|-> x * y ))
+values:
+  value: (( .mult(2)(5) ))
+`)
+
+				resolved := parseYAML(`
+---
+values:
+  value: 10
+`)
+				Expect(template).To(CascadeAs(resolved, source))
+			})
+			
+			It("supports chained references", func() {
+				source := parseYAML(`
+---
+func:
+  mult: (( lambda |x,y|-> x * y ))
+values:
+  value: (( (|x|->x)(func).mult(2,5) ))
+`)
+
+				resolved := parseYAML(`
+---
+values:
+  value: 10
+`)
+				Expect(template).To(CascadeAs(resolved, source))
+			})
 		})
 
 		Context("cross stub", func() {

--- a/flow/cascade_test.go
+++ b/flow/cascade_test.go
@@ -288,6 +288,23 @@ values:
 `)
 				Expect(template).To(CascadeAs(resolved, source))
 			})
+
+			It("passes binding to nested lambda expressions", func() {
+				source := parseYAML(`
+---
+mult: (( lambda |x|-> lambda |y|-> x * y ))
+mult2: (( .mult(2) ))
+values:
+  value: (( .mult2(3) ))
+`)
+
+				resolved := parseYAML(`
+---
+values:
+  value: 6
+`)
+				Expect(template).To(CascadeAs(resolved, source))
+			})
 		})
 
 		Context("cross stub", func() {

--- a/flow/cascade_test.go
+++ b/flow/cascade_test.go
@@ -354,7 +354,7 @@ values:
 `)
 				Expect(template).To(CascadeAs(resolved, source))
 			})
-			
+
 			It("supports chained references", func() {
 				source := parseYAML(`
 ---

--- a/flow/cascade_test.go
+++ b/flow/cascade_test.go
@@ -305,6 +305,22 @@ values:
 `)
 				Expect(template).To(CascadeAs(resolved, source))
 			})
+
+			It("supports self recursion", func() {
+				source := parseYAML(`
+---
+fibonacci: (( lambda |x|-> x <= 0 ? 0 :x == 1 ? 1 :_(x - 2) + _( x - 1 ) ))
+values:
+  value: (( .fibonacci(5) ))
+`)
+
+				resolved := parseYAML(`
+---
+values:
+  value: 5
+`)
+				Expect(template).To(CascadeAs(resolved, source))
+			})
 		})
 
 		Context("cross stub", func() {

--- a/flow/environment.go
+++ b/flow/environment.go
@@ -1,34 +1,60 @@
 package flow
 
 import (
+	"reflect"
+
+	"github.com/cloudfoundry-incubator/spiff/debug"
+	"github.com/cloudfoundry-incubator/spiff/dynaml"
 	"github.com/cloudfoundry-incubator/spiff/yaml"
 )
 
-type Scope []map[string]yaml.Node
-
-type Environment struct {
-	Scope Scope
-	Path  []string
-
-	Stubs []yaml.Node
-
-	StubPath []string
+type Scope struct {
+	local map[string]yaml.Node
+	next  *Scope
+	root  *Scope
 }
 
-func (e Environment) GetLocalBinding() map[string]yaml.Node {
+func newScope(outer *Scope, local map[string]yaml.Node) *Scope {
+	scope := &Scope{local, outer, nil}
+	if outer == nil {
+		scope.root = scope
+	} else {
+		scope.root = outer.root
+	}
+	return scope
+}
+
+type DefaultEnvironment struct {
+	scope *Scope
+	path  []string
+
+	stubs []yaml.Node
+
+	stubPath []string
+}
+
+func (e DefaultEnvironment) Path() []string {
+	return e.path
+}
+
+func (e DefaultEnvironment) StubPath() []string {
+	return e.stubPath
+}
+
+func (e DefaultEnvironment) GetLocalBinding() map[string]yaml.Node {
 	return map[string]yaml.Node{}
 }
 
-func (e Environment) FindFromRoot(path []string) (yaml.Node, bool) {
-	if len(e.Scope) == 0 {
+func (e DefaultEnvironment) FindFromRoot(path []string) (yaml.Node, bool) {
+	if e.scope == nil {
 		return nil, false
 	}
 
-	return yaml.FindR(true, yaml.NewNode(e.Scope[0], "scope"), path...)
+	return yaml.FindR(true, yaml.NewNode(e.scope.root.local, "scope"), path...)
 }
 
-func (e Environment) FindReference(path []string) (yaml.Node, bool) {
-	root, found := resolveSymbol(path[0], e.Scope)
+func (e DefaultEnvironment) FindReference(path []string) (yaml.Node, bool) {
+	root, found := resolveSymbol(path[0], e.scope)
 	if !found {
 		return nil, false
 	}
@@ -36,8 +62,8 @@ func (e Environment) FindReference(path []string) (yaml.Node, bool) {
 	return yaml.FindR(true, root, path[1:]...)
 }
 
-func (e Environment) FindInStubs(path []string) (yaml.Node, bool) {
-	for _, stub := range e.Stubs {
+func (e DefaultEnvironment) FindInStubs(path []string) (yaml.Node, bool) {
+	for _, stub := range e.stubs {
 		val, found := yaml.Find(stub, path...)
 		if found {
 			return val, true
@@ -47,36 +73,61 @@ func (e Environment) FindInStubs(path []string) (yaml.Node, bool) {
 	return nil, false
 }
 
-func (e Environment) WithScope(step map[string]yaml.Node) Environment {
-	newScope := make([]map[string]yaml.Node, len(e.Scope))
-	copy(newScope, e.Scope)
-	e.Scope = append(newScope, step)
+func (e DefaultEnvironment) WithScope(step map[string]yaml.Node) dynaml.Binding {
+	e.scope = newScope(e.scope, step)
 	return e
 }
 
-func (e Environment) WithPath(step string) Environment {
-	newPath := make([]string, len(e.Path))
-	copy(newPath, e.Path)
-	e.Path = append(newPath, step)
+func (e DefaultEnvironment) WithPath(step string) dynaml.Binding {
+	newPath := make([]string, len(e.path))
+	copy(newPath, e.path)
+	e.path = append(newPath, step)
 
-	newPath = make([]string, len(e.StubPath))
-	copy(newPath, e.StubPath)
-	e.StubPath = append(newPath, step)
+	newPath = make([]string, len(e.stubPath))
+	copy(newPath, e.stubPath)
+	e.stubPath = append(newPath, step)
 	return e
 }
 
-func (e Environment) RedirectOverwrite(path []string) Environment {
-	e.StubPath = path
+func (e DefaultEnvironment) RedirectOverwrite(path []string) dynaml.Binding {
+	e.stubPath = path
 	return e
 }
 
-func resolveSymbol(name string, context Scope) (yaml.Node, bool) {
-	for i := len(context); i > 0; i-- {
-		ctx := context[i-1]
-		val := ctx[name]
+func (e DefaultEnvironment) Flow(source yaml.Node, shouldOverride bool) (yaml.Node, error) {
+	result := source
+
+	for {
+		debug.Debug("@@@ loop:  %+v\n", result)
+		next := flow(result, e, shouldOverride)
+		debug.Debug("@@@ --->   %+v\n", next)
+
+		if reflect.DeepEqual(result, next) {
+			break
+		}
+
+		result = next
+	}
+	debug.Debug("@@@ Done\n")
+	unresolved := dynaml.FindUnresolvedNodes(result)
+	if len(unresolved) > 0 {
+		return nil, dynaml.UnresolvedNodes{unresolved}
+	}
+
+	return result, nil
+}
+
+func NewEnvironment(stubs []yaml.Node) dynaml.Binding {
+	return DefaultEnvironment{stubs: stubs}
+}
+
+func resolveSymbol(name string, scope *Scope) (yaml.Node, bool) {
+	for scope != nil {
+		val := scope.local[name]
 		if val != nil {
 			return val, true
 		}
+		scope = scope.next
 	}
 
 	return nil, false

--- a/flow/environment.go
+++ b/flow/environment.go
@@ -15,6 +15,10 @@ type Environment struct {
 	StubPath []string
 }
 
+func (e Environment) GetLocalBinding() map[string]yaml.Node {
+	return map[string]yaml.Node{}
+}
+
 func (e Environment) FindFromRoot(path []string) (yaml.Node, bool) {
 	if len(e.Scope) == 0 {
 		return nil, false

--- a/flow/environment.go
+++ b/flow/environment.go
@@ -94,7 +94,7 @@ func (e DefaultEnvironment) RedirectOverwrite(path []string) dynaml.Binding {
 	return e
 }
 
-func (e DefaultEnvironment) Flow(source yaml.Node, shouldOverride bool) (yaml.Node, error) {
+func (e DefaultEnvironment) Flow(source yaml.Node, shouldOverride bool) (yaml.Node, dynaml.Status) {
 	result := source
 
 	for {

--- a/flow/environment_test.go
+++ b/flow/environment_test.go
@@ -15,8 +15,8 @@ foo:
   bar: 42
  `)
 
-		environment := Environment{
-			Scope: []map[string]yaml.Node{tree.Value().(map[string]yaml.Node)},
+		environment := DefaultEnvironment{
+			scope: newScope(nil, tree.Value().(map[string]yaml.Node)),
 		}
 
 		Context("when the first step is found", func() {
@@ -36,8 +36,8 @@ foos:
   baz: 42
 `)
 
-				environment := Environment{
-					Scope: []map[string]yaml.Node{tree.Value().(map[string]yaml.Node)},
+				environment := DefaultEnvironment{
+					scope: newScope(nil, tree.Value().(map[string]yaml.Node)),
 				}
 
 				It("treats the name as the key", func() {
@@ -65,12 +65,11 @@ foo:
     buzz: 42
 `)
 
-			environment := Environment{
-				Scope: []map[string]yaml.Node{
-					tree.Value().(map[string]yaml.Node),
-					tree.Value().(map[string]yaml.Node)["foo"].Value().(map[string]yaml.Node),
-					tree.Value().(map[string]yaml.Node)["foo"].Value().(map[string]yaml.Node)["bar"].Value().(map[string]yaml.Node),
-				},
+			environment := DefaultEnvironment{
+				scope: newScope(newScope(newScope(nil,
+					tree.Value().(map[string]yaml.Node)),
+					tree.Value().(map[string]yaml.Node)["foo"].Value().(map[string]yaml.Node)),
+					tree.Value().(map[string]yaml.Node)["foo"].Value().(map[string]yaml.Node)["bar"].Value().(map[string]yaml.Node)),
 			}
 
 			It("finds the root and the path", func() {
@@ -92,12 +91,11 @@ foo:
     buzz: 42
 `)
 
-			environment := Environment{
-				Scope: []map[string]yaml.Node{
-					tree.Value().(map[string]yaml.Node),
-					tree.Value().(map[string]yaml.Node)["foo"].Value().(map[string]yaml.Node),
-					tree.Value().(map[string]yaml.Node)["foo"].Value().(map[string]yaml.Node)["bar"].Value().(map[string]yaml.Node),
-				},
+			environment := DefaultEnvironment{
+				scope: newScope(newScope(newScope(nil,
+					tree.Value().(map[string]yaml.Node)),
+					tree.Value().(map[string]yaml.Node)["foo"].Value().(map[string]yaml.Node)),
+					tree.Value().(map[string]yaml.Node)["foo"].Value().(map[string]yaml.Node)["bar"].Value().(map[string]yaml.Node)),
 			}
 
 			It("finds the nearest occurrence", func() {
@@ -123,10 +121,8 @@ foo:
     baz: found
 `)
 
-		environment := Environment{
-			Scope: []map[string]yaml.Node{
-				tree.Value().(map[string]yaml.Node),
-			},
+		environment := DefaultEnvironment{
+			scope: newScope(nil, tree.Value().(map[string]yaml.Node)),
 		}
 
 		It("returns the node found by the path from the root", func() {
@@ -144,10 +140,8 @@ foo:
     - fizz: right
 `)
 
-			environment := Environment{
-				Scope: []map[string]yaml.Node{
-					tree.Value().(map[string]yaml.Node),
-				},
+			environment := DefaultEnvironment{
+				scope: newScope(nil, tree.Value().(map[string]yaml.Node)),
 			}
 
 			It("accepts [x] for following through lists", func() {
@@ -178,8 +172,8 @@ b: 2
 c: 4
 `)
 
-		environment := Environment{
-			Stubs: []yaml.Node{stub1, stub2},
+		environment := DefaultEnvironment{
+			stubs: []yaml.Node{stub1, stub2},
 		}
 
 		Context("when the first stub contains the path", func() {

--- a/flow/error_check_test.go
+++ b/flow/error_check_test.go
@@ -139,6 +139,17 @@ node: (( "." a ))
 		))
 	})
 
+	It("reports length", func() {
+		source := parseYAML(`
+---
+
+node: (( length( 5 ) ))
+`)
+		Expect(source).To(FlowToErr(
+			`	(( length(5) ))	in test	node	()	invalid type for function length`,
+		))
+	})
+
 	It("reports unparseable", func() {
 		source := parseYAML(`
 ---

--- a/flow/flow.go
+++ b/flow/flow.go
@@ -58,7 +58,7 @@ func flow(root yaml.Node, env Environment, shouldOverride bool) yaml.Node {
 			return flowList(root, env)
 
 		case dynaml.Expression:
-			debug.Debug("??? eval %+v\n", val)
+			debug.Debug("??? eval %T: %+v\n", val, val)
 			result, info, ok := val.Evaluate(env)
 			if !ok {
 				root = yaml.IssueNode(root, info.Issue)

--- a/flow/flow_test.go
+++ b/flow/flow_test.go
@@ -2289,6 +2289,75 @@ foo: failed
 		})
 	})
 
+	Describe("when splitting", func() {
+		It("splits single value", func() {
+			source := parseYAML(`
+---
+foo: (( split( ",", "alice") ))
+`)
+			resolved := parseYAML(`
+---
+foo:
+ - alice
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("splits multiple values", func() {
+			source := parseYAML(`
+---
+foo: (( split( ",", "alice,bob") ))
+`)
+			resolved := parseYAML(`
+---
+foo:
+ - alice
+ - bob
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+	})
+
+	Describe("when trimming", func() {
+		It("trims strings", func() {
+			source := parseYAML(`
+---
+foo: (( trim( "  alice ") ))
+`)
+			resolved := parseYAML(`
+---
+foo: alice
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("trims dedicated characters", func() {
+			source := parseYAML(`
+---
+foo: (( trim( "alice", "ae") ))
+`)
+			resolved := parseYAML(`
+---
+foo: lic
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("trims lists", func() {
+			source := parseYAML(`
+---
+foo: (( trim( split(",","alice, bob ")) ))
+`)
+			resolved := parseYAML(`
+---
+foo:
+  - alice
+  - bob
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+	})
+
 	Describe("when doing a mapping", func() {
 		Context("for a list", func() {
 			It("maps simple expression", func() {

--- a/flow/flow_test.go
+++ b/flow/flow_test.go
@@ -2007,6 +2007,198 @@ foo: "1515"
 		})
 	})
 
+	Describe("for logical expressions", func() {
+		It("evaluates not", func() {
+			source := parseYAML(`
+---
+foo: (( 5 ))
+bar: (( !foo ))
+`)
+			resolved := parseYAML(`
+---
+foo: 5
+bar: false
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("evaluates and", func() {
+			source := parseYAML(`
+---
+foo: (( 0 ))
+bar: (( !foo -and true))
+`)
+			resolved := parseYAML(`
+---
+foo: 0
+bar: true
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("evaluates or", func() {
+			source := parseYAML(`
+---
+foo: (( 5 ))
+bar: (( !foo -or true))
+`)
+			resolved := parseYAML(`
+---
+foo: 5
+bar: true
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("evaluates <=", func() {
+			source := parseYAML(`
+---
+foo: (( 5 ))
+bar: (( foo <= 5))
+`)
+			resolved := parseYAML(`
+---
+foo: 5
+bar: true
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("evaluates <", func() {
+			source := parseYAML(`
+---
+foo: (( 5 ))
+bar: (( foo < 5))
+`)
+			resolved := parseYAML(`
+---
+foo: 5
+bar: false
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("evaluates >=", func() {
+			source := parseYAML(`
+---
+foo: (( 5 ))
+bar: (( foo >= 5))
+`)
+			resolved := parseYAML(`
+---
+foo: 5
+bar: true
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("evaluates >", func() {
+			source := parseYAML(`
+---
+foo: (( 5 ))
+bar: (( foo > 5))
+`)
+			resolved := parseYAML(`
+---
+foo: 5
+bar: false
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("evaluates ==", func() {
+			source := parseYAML(`
+---
+foo: (( 5 ))
+bar: (( foo == 5))
+`)
+			resolved := parseYAML(`
+---
+foo: 5
+bar: true
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("evaluates == of lists", func() {
+			source := parseYAML(`
+---
+foo: 
+  - alice
+  - bob
+bar: (( foo == [ "alice","bob" ] ))
+`)
+			resolved := parseYAML(`
+---
+foo: 
+  - alice
+  - bob
+bar: true
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("evaluates == of lists to false", func() {
+			source := parseYAML(`
+---
+foo: 
+  - alice
+  - bob
+bar: (( foo == [ "alice","paul" ] ))
+`)
+			resolved := parseYAML(`
+---
+foo: 
+  - alice
+  - bob
+bar: false
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("evaluates == of maps", func() {
+			source := parseYAML(`
+---
+foo: 
+  a: 1
+  b: 2
+
+comp:
+  a: 1
+  b: 2
+
+bar: (( foo == comp ))
+`)
+			resolved := parseYAML(`
+---
+foo: 
+  a: 1
+  b: 2
+
+comp:
+  a: 1
+  b: 2
+
+bar: true
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("evaluates !=", func() {
+			source := parseYAML(`
+---
+foo: (( 5 ))
+bar: (( foo != 5))
+`)
+			resolved := parseYAML(`
+---
+foo: 5
+bar: false
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+	})
+
 	Describe("when concatenating a list", func() {
 		Context("with incremental expression resolution", func() {
 			It("evaluates in case of successfully completed operand resolution", func() {

--- a/flow/flow_test.go
+++ b/flow/flow_test.go
@@ -264,7 +264,7 @@ foo: (( auto ))
 						Node: yaml.IssueNode(yaml.NewNode(
 							dynaml.AutoExpr{Path: []string{"foo"}},
 							"test",
-						), "auto only allowed for size entry in resource pools"),
+						), yaml.NewIssue("auto only allowed for size entry in resource pools")),
 						Context: []string{"foo"},
 						Path:    []string{"foo"},
 					},

--- a/flow/flow_test.go
+++ b/flow/flow_test.go
@@ -2595,6 +2595,54 @@ foo: 2
 		})
 	})
 
+	Describe("when reevaluating an expression", func() {
+		It("resolves indirect fields", func() {
+			source := parseYAML(`
+---
+alice:
+  bob: married
+
+foo: alice
+bar: bob
+
+status: (( eval( foo "." bar ) ))
+`)
+			resolved := parseYAML(`
+---
+alice:
+  bob: married
+
+foo: alice
+bar: bob
+
+status: married
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("defaults evaluation errors", func() {
+			source := parseYAML(`
+---
+alice:
+  bob: married
+
+foo: alice
+
+status: (( eval( foo "." bar ) || "failed" ))
+`)
+			resolved := parseYAML(`
+---
+alice:
+  bob: married
+
+foo: alice
+
+status: failed
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+	})
+
 	Describe("when doing a mapping", func() {
 		Context("for a list", func() {
 			It("maps simple expression", func() {

--- a/flow/flow_test.go
+++ b/flow/flow_test.go
@@ -1,6 +1,8 @@
 package flow
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -2638,6 +2640,70 @@ alice:
 foo: alice
 
 status: failed
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+	})
+
+	Describe("when resing from the environment", func() {
+		os.Setenv("TEST1", "alice")
+		os.Setenv("TEST2", "bob")
+		dynaml.ReloadEnv()
+
+		It("resolves a single variable", func() {
+			source := parseYAML(`
+---
+alice: (( env("TEST1") ))
+`)
+			resolved := parseYAML(`
+---
+alice: alice
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("defaults a non-existing single variable", func() {
+			source := parseYAML(`
+---
+alice: (( env("TEST3") || "default" ))
+`)
+			resolved := parseYAML(`
+---
+alice: default
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("resolves a two variables to a map", func() {
+			source := parseYAML(`
+---
+env: (( env("TEST1","TEST2") ))
+`)
+			resolved := parseYAML(`
+---
+env:
+  TEST1: alice
+  TEST2: bob
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("resolves a list to a map", func() {
+			source := parseYAML(`
+---
+list:
+  - TEST1
+  - TEST2
+env: (( env(list) ))
+`)
+			resolved := parseYAML(`
+---
+list:
+  - TEST1
+  - TEST2
+env:
+  TEST1: alice
+  TEST2: bob
 `)
 			Expect(source).To(FlowAs(resolved))
 		})

--- a/flow/flow_test.go
+++ b/flow/flow_test.go
@@ -2643,6 +2643,61 @@ status: failed
 		})
 	})
 
+	Describe("when formatting a string", func() {
+		It("formats strings and integers", func() {
+			source := parseYAML(`
+---
+int: 5
+str: string
+msg: (( format("%s %d", str, int) ))
+`)
+			resolved := parseYAML(`
+---
+int: 5
+str: string
+msg: string 5
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("formats maps", func() {
+			source := parseYAML(`
+---
+map:
+  alice: 25
+msg: (( format("%s", map) ))
+`)
+			resolved := parseYAML(`
+---
+map:
+  alice: 25
+msg: |+
+  alice: 25
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("formats lists", func() {
+			source := parseYAML(`
+---
+list:
+  - alice
+  - bob
+msg: (( format("%s", list) ))
+`)
+			resolved := parseYAML(`
+---
+list:
+  - alice
+  - bob
+msg: |+
+  - alice
+  - bob
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+	})
+
 	Describe("when doing a mapping", func() {
 		Context("for a list", func() {
 			It("maps simple expression", func() {

--- a/flow/flow_test.go
+++ b/flow/flow_test.go
@@ -2358,6 +2358,51 @@ foo:
 		})
 	})
 
+	Describe("calling length", func() {
+		It("calculates string length", func() {
+			source := parseYAML(`
+---
+foo: (( length( "alice") ))
+`)
+			resolved := parseYAML(`
+---
+foo: 5
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("calculates list length", func() {
+			source := parseYAML(`
+---
+foo: (( length( ["alice","bob"]) ))
+`)
+			resolved := parseYAML(`
+---
+foo: 2
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+
+		It("calculates map length", func() {
+			source := parseYAML(`
+---
+map:
+  alice: 25
+  bob: 24
+
+foo: (( length( map) ))
+`)
+			resolved := parseYAML(`
+---
+map:
+  alice: 25
+  bob: 24
+foo: 2
+`)
+			Expect(source).To(FlowAs(resolved))
+		})
+	})
+
 	Describe("when doing a mapping", func() {
 		Context("for a list", func() {
 			It("maps simple expression", func() {

--- a/flow/flow_test.go
+++ b/flow/flow_test.go
@@ -2454,6 +2454,28 @@ joined: failed
 `)
 				Expect(source).To(FlowAs(resolved))
 			})
+
+			It("maps with referenced expression", func() {
+				source := parseYAML(`
+---
+map: '|x|->x'
+list:
+  - alice
+  - bob
+mapped: (( map[list|lambda map] ))
+`)
+				resolved := parseYAML(`
+---
+map: '|x|->x'
+list:
+  - alice
+  - bob
+mapped:
+  - alice
+  - bob
+`)
+				Expect(source).To(FlowAs(resolved))
+			})
 		})
 
 		Context("for a map", func() {

--- a/flow/flow_test.go
+++ b/flow/flow_test.go
@@ -2827,6 +2827,84 @@ mapped:
 		})
 	})
 
+	Describe("using templates", func() {
+		Context("direct usage", func() {
+			It("uses usage context", func() {
+				source := parseYAML(`
+---
+verb: hates
+
+foo:
+  bar:
+    <<: (( &template ))
+    alice: alice
+    bob: (( verb " " alice ))
+
+
+use:
+  verb: loves
+  subst: (( *foo.bar ))
+`)
+				resolved, _ := Flow(parseYAML(`
+---
+foo:
+  bar:
+    <<: (( &template ))
+    alice: alice
+    bob: (( verb " " alice ))
+use:
+  subst:
+    alice: alice
+    bob: loves alice
+  verb: loves
+verb: hates
+`))
+				Expect(source).To(FlowAs(resolved))
+			})
+
+			It("handles independent usage", func() {
+				source := parseYAML(`
+---
+verb: hates
+
+foo:
+  bar:
+    <<: (( &template ))
+    alice: alice
+    bob: (( verb " " alice ))
+
+
+use1:
+  verb: loves
+  subst: (( *foo.bar ))
+use2:
+  verb: works with
+  subst: (( *foo.bar ))
+`)
+				resolved, _ := Flow(parseYAML(`
+---
+foo:
+  bar:
+    <<: (( &template ))
+    alice: alice
+    bob: (( verb " " alice ))
+use1:
+  subst:
+    alice: alice
+    bob: loves alice
+  verb: loves
+use2:
+  subst:
+    alice: alice
+    bob: works with alice
+  verb: works with
+verb: hates
+`))
+				Expect(source).To(FlowAs(resolved))
+			})
+		})
+	})
+
 	Describe("merging lists with specified key", func() {
 		Context("no merge", func() {
 			It("clean up key tag", func() {

--- a/spiff.go
+++ b/spiff.go
@@ -21,7 +21,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "spiff"
 	app.Usage = "BOSH deployment manifest toolkit"
-	app.Version = "1.0.8dev"
+	app.Version = "1.0.8dev2"
 
 	app.Commands = []cli.Command{
 		{


### PR DESCRIPTION
This pull request adds two major features to spiff:
- Dynamic functions
  The value of a dynaml expression might now be a function value described by a lambda expression. This function can then be called in any other dynaml expression by passing an approriate number of arguments in addition to the standard builtin functions. As new kind of values for the yaml document, they can be assigned to other properties and merged among multiple merge stubs.
- Templates
  Templates are yaml fragments (parts of the reqular yaml file) that are explicitly tagged. They may contain dynaml expressions that will not be evaluated at its definition location. Using a dedicated reference expression they can be evaluated in the context of any dynaml expession. The contained references will be resolved in this context, so relative element paths are evaluated relative to the using element. Additionally they can be combined with dynaml functions by supporting the function parameter names as additional binding context. This way it is possible to provide functions returning complex structures supporting dynaml expressions for its values refering to function arguments.

Besides these major features there are several supporting features:
- the programming of function makes sense only if there is a way to react on conditions. Therefore dynaml has been extended to support logical (`-or`/`-and`), comparison (`==`,`<=`,`>=`,`>`,`<`,`!=`,`!`), and conditional (`?:`)  operators. 
- to work with deep structures chaining of expressions, function calls and references is possible now (`.foo.bar(alice,bob).property`)
- lots of additional builtin functions have been added
  - `eval`: reevaluate a string as dynaml expression to support access to composed attribute paths.
  -  `env`: to access environment variables
  - `format`: to format strings based on arguments (GO Sprint function)
  - `length`: length of strings, maps and lists
  - `num_ip`: number of IPs in a CIDR
  - `split`: split a string
  - `trim`: removeleading and trailing white spaces (or other characters)

There are lots of examples in the documentation.