### PR TITLE
make sure nodes that start with ! are ignored

### DIFF
--- a/flow/flow_test.go
+++ b/flow/flow_test.go
@@ -103,6 +103,22 @@ foo: (( auto ))
 		})
 	})
 
+	Context("when there are ignorable dynaml nodes start with '!'", func() {
+		It("ignores nodes", func() {
+			source := parseYAML(`
+---
+foo: ((!template_only.foo))
+`)
+
+			resolved := parseYAML(`
+---
+foo: ((!template_only.foo))
+`)
+
+			Expect(source).To(FlowAs(resolved))
+		})
+	})
+
 	Context("when a reference is made to a yet-to-be-resolved node, in a || expression", func() {
 		It("eventually resolves to the referenced node", func() {
 			source := parseYAML(`


### PR DESCRIPTION
so that bosh config server integration can cooperate with spiff.

seems to already work.